### PR TITLE
README note about alternative folder for chatmode files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ The process emphasizes **clarity, traceability, and recoverability**, letting de
 ## Getting Started
 
 - Copy the .github/chatmodes into your repository's `.github/chatmodes` folder. This will make them available in VS Code's Github Copilot chat.
+  - *Make them apply to all projects by copying to VS Code's global configuration directory (e.g. on Windows `%APPDATA%\Code\User\prompts`).*
 - Follow the workflow as described below and detailed in the [PAW Specification](paw-specification.md).
 
 ## Workflow


### PR DESCRIPTION
It may be a little more convenient for some users to place the chatmode files under VS Code's global config directory because:
* the modes are then available for all projects
* avoid creating the .github/chatmodes folder in each project
* avoid adding the chatmodes folder to .gitignore OR adding the files one by one if the project itself has custom chatmodes.