### PR TITLE
Add PR labeling requirements to copilot instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -9,3 +9,11 @@ When creating or modifying chatmode files in `.github/chatmodes/`, ALWAYS run th
 ```bash
 ./scripts/lint-chatmode.sh .github/chatmodes/<filename>.chatmode.md
 ```
+
+## Pull Request Labels
+
+All pull requests to `main` must be labeled with one of the following labels:
+- `enhancement` - For new features
+- `bug` - For bug fixes
+- `documentation` - For documentation changes
+- `maintenance` - For maintenance, refactoring, or chores


### PR DESCRIPTION
## Overview

Adds clear labeling requirements to `.github/copilot-instructions.md` to ensure all PRs to `main` are properly categorized for automated release changelogs.

## Changes

Updated copilot instructions to require all PRs to `main` be labeled with one of:
- `enhancement` - For new features
- `bug` - For bug fixes
- `documentation` - For documentation changes
- `maintenance` - For maintenance, refactoring, or chores

## Why

These labels are used by the GitHub Actions release workflow to automatically categorize PRs in release changelogs. Without proper labeling, PRs won't appear in the correct sections of release notes.

## Files Changed

- `.github/copilot-instructions.md` - Added "Pull Request Labels" section with labeling requirements

---

**Label**: `documentation` (updating project documentation/instructions)