### PR TITLE
[MkDocs GitHub Pages Setup] Phase 2: GitHub Actions Publishing

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,66 @@
+# Builds and deploys documentation to GitHub Pages when changes are merged to main.
+# Uses MkDocs with Material theme for static site generation.
+# Publishes to https://lossyrob.github.io/phased-agent-workflow
+name: Deploy Documentation
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - '.github/workflows/docs.yml'
+
+permissions:
+  contents: write  # Required to push to gh-pages branch
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      
+      - name: Configure Git credentials
+        run: |
+          # Configure git for github-actions bot to push to gh-pages branch
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+      
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
+      
+      - name: Set cache ID
+        run: |
+          # Use week number for weekly cache refresh
+          # This balances freshness with build speed
+          echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV
+      
+      - name: Cache MkDocs Material assets
+        uses: actions/cache@v4
+        with:
+          key: mkdocs-material-${{ env.cache_id }}
+          path: .cache
+          restore-keys: |
+            mkdocs-material-
+      
+      - name: Install MkDocs Material
+        run: pip install mkdocs-material
+      
+      - name: Deploy to GitHub Pages
+        run: |
+          # Build and deploy documentation to gh-pages branch
+          # --force overwrites history to keep gh-pages clean
+          mkdocs gh-deploy --force
+      
+      - name: Deployment summary
+        if: success()
+        run: |
+          echo "✅ Documentation deployed successfully!"
+          echo "- Site URL: https://lossyrob.github.io/phased-agent-workflow"
+          echo "- Source: docs/ and mkdocs.yml"
+          echo "- Branch: gh-pages"

--- a/.paw/work/mkdocs-github-pages/ImplementationPlan.md
+++ b/.paw/work/mkdocs-github-pages/ImplementationPlan.md
@@ -171,7 +171,7 @@ Add automated deployment workflow to publish documentation to GitHub Pages on me
 ### Success Criteria:
 
 #### Automated Verification:
-- [ ] GitHub Actions workflow passes syntax validation
+- [x] GitHub Actions workflow passes syntax validation
 - [ ] Workflow runs successfully on push to main (visible in Actions tab)
 
 #### Manual Verification:
@@ -180,6 +180,21 @@ Add automated deployment workflow to publish documentation to GitHub Pages on me
 - [ ] **Search functional**: Search input finds terms from documentation content
 - [ ] **Navigation displays**: Left sidebar shows documentation structure
 - [ ] **Mobile responsive**: Site renders correctly on mobile viewport
+
+### Phase 2 Implementation Notes
+
+**Completed**: 2025-12-09
+
+**Summary**: GitHub Actions workflow created at `.github/workflows/docs.yml` with:
+- Trigger on push to `main` with path filter for `docs/**`, `mkdocs.yml`, and the workflow itself
+- `contents: write` permission for pushing to `gh-pages` branch
+- Git credential configuration for github-actions[bot]
+- Python setup with `actions/setup-python@v5`
+- Weekly cache for MkDocs Material assets using `%V` week number pattern
+- `mkdocs gh-deploy --force` for automated deployment
+- Follows project workflow patterns (descriptive header comments, action version pinning, summary step)
+
+**Notes for reviewers**: After merging to main, manually enable GitHub Pages in repository settings (Settings → Pages → Source: "Deploy from a branch" → Branch: `gh-pages` / `/ (root)`).
 
 ### Post-Phase Notes
 


### PR DESCRIPTION
## Summary

Adds GitHub Actions workflow for automated MkDocs documentation deployment to GitHub Pages.

## Changes

- **New file**: `.github/workflows/docs.yml` - Automated deployment workflow with:
  - Trigger on push to `main` with path filter for `docs/**`, `mkdocs.yml`, and workflow file
  - `contents: write` permission for pushing to `gh-pages` branch
  - Git credential configuration for `github-actions[bot]`
  - Python setup with `actions/setup-python@v5`
  - Weekly cache for MkDocs Material assets using `%V` week number pattern
  - `mkdocs gh-deploy --force` for automated deployment
  - Follows project workflow patterns (descriptive header comments, action version pinning, summary step)

## Post-Merge Setup Required

After merging to main, the repository owner must enable GitHub Pages:
1. Navigate to repository Settings → Pages
2. Under "Build and deployment", select:
   - Source: "Deploy from a branch"
   - Branch: `gh-pages` / `/ (root)`
3. Save settings

The site will be accessible at https://lossyrob.github.io/phased-agent-workflow

## Review Summary

✅ **Pattern Compliance**: Follows established project patterns from `pr-checks.yml` and `release.yml`
✅ **Correct Configuration**: Proper triggers, permissions, and git credentials
✅ **Smart Caching**: Weekly cache refresh balances freshness with build speed
✅ **Well-Documented**: Clear comments explaining each step's purpose
✅ **YAML Syntax**: Validated successfully

## Related

- Closes phase 2 of #109
- Implementation Plan: `.paw/work/mkdocs-github-pages/ImplementationPlan.md`

---
🐾 Generated with [PAW](https://github.com/lossyrob/phased-agent-workflow)