### PR TITLE
fix: filter intermediate phase PRs from release changelog

### DIFF
--- a/.github/prompts/prepare-release.prompt.md
+++ b/.github/prompts/prepare-release.prompt.md
@@ -35,7 +35,9 @@ Ask the user to confirm the version number before proceeding.
 
 ### 2. Identify PRs for Release
 
-Find the last release tag and its commit date. Then search for all merged PRs to the main branch since that date. You should get the PR number, title, labels, and merge date for each PR.
+Find the last release tag and its commit date. Then search for all merged PRs **that target the main branch** since that date. You should get the PR number, title, labels, base branch, and merge date for each PR.
+
+**IMPORTANT:** Only include PRs where the base/target branch is `main`. Exclude PRs that targeted feature branches (these are intermediate phase PRs that were merged into a feature branch before the final PR merged to main).
 
 Review the results to identify PRs that need labels.
 
@@ -67,7 +69,9 @@ Ensure no PRs are missing labels. If any are still unlabeled, repeat step 3.
 
 ### 5. Generate Changelog Preview
 
-Generate a changelog preview organized by label category. Search for merged PRs since the last release filtered by each label:
+Generate a changelog preview organized by label category. Only include PRs that were identified in step 2 (i.e., PRs that target `main` branch).
+
+Search for merged PRs since the last release filtered by each label:
 - `enhancement` for Features
 - `bug` for Bug Fixes
 - `documentation` for Documentation


### PR DESCRIPTION
## Summary

Improves the prepare-release prompt to filter out intermediate phase PRs from the release changelog. 

**Problem**: When multi-phase work is done (e.g., MkDocs GitHub Pages setup with phases 1-4), all the intermediate phase PRs were being included in the changelog even though they targeted a feature branch, not main. This cluttered the changelog with internal workflow PRs that users don't need to see.

**Solution**: Updated the prompt instructions in two places:
1. **Step 2 (Identify PRs for Release)**: Now explicitly instructs to only include PRs that target `main` branch and exclude PRs that targeted feature branches
2. **Step 5 (Generate Changelog Preview)**: Simplified to only include PRs identified in step 2 (which already filters by base branch)

This approach is simpler and more reliable than trying to parse PR titles for "Phase X:" patterns - the base branch is the authoritative indicator of whether a PR should be in the release notes.

## Changes

- `.github/prompts/prepare-release.prompt.md`: Added base branch filtering instructions

## Testing

Verified using GitHub MCP `list_pull_requests` tool that the `base.ref` field correctly shows the target branch (e.g., `main` vs `feature/109-mkdocs-github-pages`).