### PR TITLE
Add 'planning-only' review policy for local strategy workflows

### DIFF
--- a/agents/PAW.agent.md
+++ b/agents/PAW.agent.md
@@ -52,6 +52,7 @@ For PRs strategy, phase branches are required (e.g., `feature/123_phase1`).
 ### Review Policy Behavior
 - `always`: Pause after every artifact for user confirmation
 - `milestones`: Pause at milestone artifacts only (Spec.md, ImplementationPlan.md, Phase PR completion, Final PR); auto-proceed at non-milestones (WorkflowContext.md, SpecResearch.md, CodeResearch.md, Docs.md)
+- `planning-only`: Pause at Spec.md, ImplementationPlan.md, and Final PR only; auto-proceed at phase completions (local strategy required)
 - `never`: Auto-proceed unless blocked
 
 **Legacy Handoff Mode mapping** (for older WorkflowContext.md files):

--- a/docs/guide/stage-transitions.md
+++ b/docs/guide/stage-transitions.md
@@ -72,6 +72,30 @@ In `milestones` mode, the workflow pauses only at key milestone artifacts:
 - Experienced PAW users who want speed with control at key points
 - Most production workflows
 
+### Planning-Only Review Policy
+
+In `planning-only` mode, the workflow pauses at specification and implementation plan milestones, then proceeds autonomously through all implementation phases until the final PR.
+
+**Pauses at:**
+
+- Spec.md (after specification is created)
+- ImplementationPlan.md (after plan is created)
+- Final PR creation
+
+**Auto-proceeds at:**
+
+- Phase completions (unlike `milestones` policy)
+- All non-milestone artifacts
+
+!!! warning "Local Strategy Required"
+    The `planning-only` review policy requires **local review strategy**. It's incompatible with PRs strategy because intermediate PR reviews require human decisions.
+
+**Best for:**
+
+- Users who want to review plans upfront, then trust autonomous execution
+- Well-specified work where planning review is sufficient
+- Workflows where phase-level interruptions slow progress unnecessarily
+
 ### Never Review Policy
 
 In `never` mode, the workflow proceeds continuously without review pauses.

--- a/skills/paw-init/SKILL.md
+++ b/skills/paw-init/SKILL.md
@@ -26,7 +26,7 @@ Bootstrap skill that initializes the PAW workflow directory structure. This runs
 | `target_branch` | No | auto-derive from work ID | branch name |
 | `workflow_mode` | No | `full` | `full`, `minimal`, `custom` |
 | `review_strategy` | No | `prs` (`local` if minimal) | `prs`, `local` |
-| `review_policy` | No | `milestones` | `always`, `milestones`, `never` |
+| `review_policy` | No | `milestones` | `always`, `milestones`, `planning-only`, `never` |
 | `session_policy` | No | `per-stage` | `per-stage`, `continuous` |
 | `track_artifacts` | No | `true` | boolean |
 | `issue_url` | No | none | URL |
@@ -58,6 +58,7 @@ This mirrors the VS Code command flow which prompts sequentially but allows skip
 
 ### Configuration Validation
 - If `workflow_mode` is `minimal`, `review_strategy` MUST be `local`
+- If `review_policy` is `planning-only` or `never`, `review_strategy` MUST be `local`
 - Invalid combinations: STOP and report error
 
 ### Directory Structure

--- a/skills/paw-transition/SKILL.md
+++ b/skills/paw-transition/SKILL.md
@@ -25,7 +25,7 @@ Read WorkflowContext.md to determine:
 - Work ID and target branch
 - Session Policy (`per-stage` | `continuous`)
 - Review Strategy (`prs` | `local`)
-- Review Policy (`always` | `milestones` | `never`)
+- Review Policy (`always` | `milestones` | `planning-only` | `never`)
   - If missing, check for legacy `Handoff Mode:` field and map: `manual`→`always`, `semi-auto`→`milestones`, `auto`→`never`
   - If neither present, default to `milestones`
 
@@ -57,6 +57,9 @@ Use the Mandatory Transitions table:
 
 **Determine pause_at_milestone**:
 - If at a milestone AND Review Policy ∈ {`always`, `milestones`}: set `pause_at_milestone = true`
+- If Review Policy = `planning-only`:
+  - If milestone is Spec.md, ImplementationPlan.md, or Final PR: set `pause_at_milestone = true`
+  - If milestone is Phase PR/phase completion: set `pause_at_milestone = false`
 - If Review Policy = `never`: set `pause_at_milestone = false`
 - If not at a milestone: set `pause_at_milestone = false`
 

--- a/src/types/workflow.ts
+++ b/src/types/workflow.ts
@@ -12,7 +12,7 @@ export type HandoffMode = "manual" | "semi-auto" | "auto";
 /**
  * Valid Review Policy values for artifact-level pause decisions.
  */
-export type ReviewPolicy = "always" | "milestones" | "never";
+export type ReviewPolicy = "always" | "milestones" | "planning-only" | "never";
 
 /**
  * Valid Session Policy values for context management.


### PR DESCRIPTION
## Summary

Adds a new `planning-only` review policy that pauses at specification and implementation plan milestones, then allows autonomous phase execution until the final PR. This supports users who want to review/approve plans upfront, then trust the agent to execute without intermediate interruptions.

## Changes

- **Type definition**: Added `planning-only` to `ReviewPolicy` union type
- **paw-transition skill**: Updated milestone pause logic (pause at Spec/Plan/Final PR, not at phase completion)
- **paw-init skill**: Added `planning-only` to valid values with local strategy validation
- **PAW agent**: Added policy behavior documentation
- **Documentation**: Added new section in stage-transitions guide

## Behavior

| Artifact | `planning-only` Pause? |
|----------|------------------------|
| Spec.md | ✅ Yes |
| ImplementationPlan.md | ✅ Yes |
| Phase completion | ❌ No |
| Final PR | ✅ Yes |

## Constraints

- Requires **local review strategy** (PRs strategy is incompatible because phase PRs require human decisions)

Closes #184