### PR TITLE
fix: Update package-lock.json with correct package name

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@paw/cli",
+  "name": "@paw-workflow/cli",
   "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@paw/cli",
+      "name": "@paw-workflow/cli",
       "version": "0.0.1",
       "license": "MIT",
       "bin": {


### PR DESCRIPTION
Updates `cli/package-lock.json` to use the correct package name `@paw-workflow/cli` (was `@paw/cli` from initial development before the rename).