### PR TITLE
fix: PAW Review skill loading and trusted publishing

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -5,6 +5,10 @@ on:
     tags:
       - 'cli-v*'
 
+permissions:
+  id-token: write  # Required for OIDC trusted publishing
+  contents: read
+
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -21,6 +25,9 @@ jobs:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'
       
+      - name: Set version from tag
+        run: npm version ${GITHUB_REF_NAME#cli-v} --no-git-tag-version
+      
       - name: Install dependencies
         run: npm ci
       
@@ -32,5 +39,3 @@ jobs:
       
       - name: Publish to npm
         run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/agents/PAW Review.agent.md
+++ b/agents/PAW Review.agent.md
@@ -8,10 +8,10 @@ You execute the PAW Review workflow by loading the workflow skill and following 
 ## Initialization
 
 {{#vscode}}
-Load the `paw-review-workflow` skill to understand orchestration, principles, and artifact structure. If the skill fails to load, report the error and stop.
+Load the `paw-review-workflow` skill using `paw_get_skill` to understand orchestration, principles, and artifact structure. If the skill fails to load, report the error and stop.
 {{/vscode}}
 {{#cli}}
-Read the `skills/paw-review-workflow/SKILL.md` file to understand orchestration, principles, and artifact structure. If the file cannot be read, report the error and stop.
+Load the `paw-review-workflow` skill to understand orchestration, principles, and artifact structure. If the skill fails to load, report the error and stop.
 {{/cli}}
 
 ## Context Detection
@@ -43,15 +43,15 @@ When cross-repository conditions are detected:
 ## Skill-Based Execution
 
 {{#vscode}}
-Use the skills catalog to discover available review skills, then execute each activity by delegating to a separate agent session. Each delegated agent:
+Use `paw_get_skills` to discover available review skills (`paw-review-*`), then execute each activity by delegating to a separate agent session. Each delegated agent:
 - Receives the skill name, PR context, and artifact path
-- Loads and executes the specified skill
+- Loads the skill using `paw_get_skill` and executes it
 - Returns a completion status with artifact confirmation
 {{/vscode}}
 {{#cli}}
-Discover available review skills from `skills/paw-review-*/SKILL.md` directories, then execute each activity by delegating to a separate agent session. Each delegated agent:
-- Receives the skill file path, PR context, and artifact path
-- Reads and executes the specified skill
+Discover available review skills (`paw-review-*`) from the skills catalog, then execute each activity by delegating to a separate agent session. Each delegated agent:
+- Receives the skill name, PR context, and artifact path
+- Loads and executes the specified skill
 - Returns a completion status with artifact confirmation
 {{/cli}}
 

--- a/skills/paw-review-workflow/SKILL.md
+++ b/skills/paw-review-workflow/SKILL.md
@@ -75,11 +75,11 @@ Activity skills are executed via delegated agent sessions.
 **Delegation prompt must include**: "First load your skill using `paw_get_skill('paw-review-<skill-name>')`, then execute the activity."
 {{/vscode}}
 {{#cli}}
-1. Read the skill file at `skills/paw-review-<skill-name>/SKILL.md`
+1. Load the skill by name (e.g., `paw-review-understanding`)
 2. Read and internalize the skill instructions
 3. Only then begin executing the activity
 
-**Delegation prompt must include**: "First read your skill from `skills/paw-review-<skill-name>/SKILL.md`, then execute the activity."
+**Delegation prompt must include**: "First load the `paw-review-<skill-name>` skill, then execute the activity."
 {{/cli}}
 
 ### Response Format


### PR DESCRIPTION
## Changes

- Remove hardcoded paths from PAW Review agent and workflow skill
- Use platform-agnostic skill loading pattern (same as PAW implementation agent)
- Enable OIDC trusted publishing for npm (no NPM_TOKEN secret needed)
- Auto-sync CLI version from git tag

## Testing

After merge, create a `cli-v0.0.2` tag to test:
1. Trusted publishing works via OIDC
2. Version is set from tag automatically