### PR TITLE
feat: add changelog and GitHub Releases for CLI publishing

### DIFF
--- a/.github/cli-release-changelog-config.json
+++ b/.github/cli-release-changelog-config.json
@@ -1,0 +1,43 @@
+{
+  "categories": [
+    {
+      "title": "## 🚀 Features",
+      "labels": ["feature", "enhancement", "feat"]
+    },
+    {
+      "title": "## 🐛 Bug Fixes",
+      "labels": ["bug", "fix"]
+    },
+    {
+      "title": "## 📚 Documentation",
+      "labels": ["documentation", "docs"]
+    },
+    {
+      "title": "## 🔧 Maintenance",
+      "labels": ["chore", "refactor", "maintenance"]
+    }
+  ],
+  "label_extractor": [
+    {
+      "pattern": ".*",
+      "on_property": "labels",
+      "method": "match",
+      "flags": "i"
+    }
+  ],
+  "ignore_labels": [
+    "ignore",
+    "wontfix",
+    "duplicate",
+    "invalid"
+  ],
+  "sort": {
+    "order": "ASC",
+    "on_property": "mergedAt"
+  },
+  "template": "#{{CHANGELOG}}\n\n## Installation\n\nInstall globally:\n\n```bash\nnpm install -g @paw-workflow/cli@#{{TO_TAG}}\n```\n\nOr run directly with npx:\n\n```bash\nnpx @paw-workflow/cli@#{{TO_TAG}}\n```\n\n---\n\n🐾 Generated with [PAW](https://github.com/lossyrob/phased-agent-workflow)",
+  "pr_template": "- #{{TITLE}} (#{{NUMBER}})",
+  "empty_template": "No CLI changes in this release",
+  "max_pull_requests": 200,
+  "max_back_track_time_days": 365
+}

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -57,11 +57,17 @@ This validates all internal links and catches configuration errors.
 
 ## Pull Request Labels
 
-All pull requests to `main` must be labeled with one of the following labels:
+All pull requests to `main` must be labeled with one of the following category labels:
 - `enhancement` - For new features
 - `bug` - For bug fixes
 - `documentation` - For documentation changes
 - `maintenance` - For maintenance, refactoring, or chores
+
+### CLI Label
+
+PRs that affect CLI code (`cli/` directory, `publish-cli.yml`, etc.) should also have the `cli` label. This label is **applied at release-prep time** using the `prepare-cli-release.prompt.md` prompt—you don't need to remember to add it during development. The prompt assesses each PR and applies the label if it affects CLI code.
+
+VS Code extension PRs don't need a special label (the extension changelog includes all PRs to main).
 
 IMPORTANT: **PAW Architecture Philosophy** - tools provide procedural operations, agents provide decision-making logic and reasoning. Rely on agents to use reasoning and logic over hardcoding procedural steps into tools.
 

--- a/.github/prompts/prepare-cli-release.prompt.md
+++ b/.github/prompts/prepare-cli-release.prompt.md
@@ -1,0 +1,123 @@
+# Prepare CLI Release
+
+This prompt guides the GitHub Copilot agent through preparing a CLI release by identifying CLI-related PRs, labeling them appropriately, and creating the release tag.
+
+## Overview
+
+You will:
+1. Identify PRs merged since the last CLI release
+2. Assess which PRs affect CLI code and apply the `cli` label
+3. Ensure all CLI PRs have category labels
+4. Generate a changelog preview
+5. Create and push the release tag
+
+## Prerequisites
+
+- The `main` branch must have a clean working directory
+- All PRs intended for the release must already be merged to `main`
+
+## Task Instructions
+
+### 1. Determine Release Version
+
+First, check the latest CLI release tags to determine the next version by listing recent tags matching `cli-v*`.
+
+Follow semantic versioning conventions:
+- **Stable releases**: `cli-v1.0.0`, `cli-v1.0.1`, `cli-v1.1.0`
+- **Pre-releases**: `cli-v1.0.0-alpha.1`, `cli-v1.0.0-beta.1`, `cli-v1.0.0-rc.1`
+
+Pre-release versions are published to the `beta` npm dist-tag and won't be installed by default.
+
+Choose the appropriate next version based on the changes:
+- **Patch release** (1.0.0 → 1.0.1): Bug fixes and minor updates
+- **Minor release** (1.0.0 → 1.1.0): New features, backward compatible
+- **Major release** (1.0.0 → 2.0.0): Breaking changes
+- **Pre-release** (1.0.0 → 1.1.0-beta.1): Testing before stable release
+
+Ask the user to confirm the version number before proceeding.
+
+### 2. Identify PRs for Release
+
+Find the last `cli-v*` release tag and its commit date. Then search for all merged PRs **that target the main branch** since that date.
+
+**IMPORTANT:** Only include PRs where the base/target branch is `main`. Exclude PRs that targeted feature branches.
+
+### 3. Assess and Label CLI PRs
+
+For each PR merged since the last release, determine if it affects CLI code. A PR should receive the `cli` label if it includes changes to:
+
+- `cli/` directory (source code, tests, scripts)
+- `.github/workflows/publish-cli.yml`
+- `.github/cli-release-changelog-config.json`
+- `.github/prompts/prepare-cli-release.prompt.md`
+- CLI-related documentation in `docs/` that specifically covers CLI usage
+
+**Labeling workflow:**
+1. Review each PR's changed files
+2. If the PR affects CLI code (per criteria above), add the `cli` label
+3. If the PR already has a category label (`enhancement`, `bug`, `documentation`, `maintenance`), keep it
+4. If the PR lacks a category label, determine the appropriate one based on the PR content and add it
+
+**Category label guidelines:**
+- `enhancement` - New features, major enhancements
+- `bug` - Bug fixes, error corrections
+- `documentation` - README updates, documentation improvements
+- `maintenance` - Refactoring, code cleanup, dependency updates, CI/CD changes
+
+Continue until all CLI-affecting PRs have both the `cli` label and a category label.
+
+### 4. Verify All CLI PRs Are Labeled
+
+Re-check that all CLI PRs now have:
+1. The `cli` label
+2. One of the category labels
+
+If any are still missing labels, repeat step 3.
+
+### 5. Generate Changelog Preview
+
+Generate a changelog preview organized by label category. **Only include PRs that have the `cli` label.**
+
+Search for merged PRs since the last release filtered by the `cli` label AND each category label:
+- `cli` + `enhancement` for Features
+- `cli` + `bug` for Bug Fixes
+- `cli` + `documentation` for Documentation
+- `cli` + `maintenance` for Maintenance
+
+Format the output as a complete changelog:
+
+```
+## 🚀 Features
+- Feature description (#123)
+
+## 🐛 Bug Fixes
+- Bug description (#124)
+
+## 📚 Documentation
+- Doc description (#125)
+
+## 🔧 Maintenance
+- Maintenance description (#126)
+```
+
+Present this changelog to the user for review.
+
+### 6. Create and Push Tag
+
+After the user approves:
+
+1. Ensure you're on the `main` branch with a clean working directory
+2. Create the annotated tag: `git tag -a cli-v<version> -m "CLI release <version>"`
+3. Push the tag: `git push origin cli-v<version>`
+
+The tag push will trigger the `publish-cli.yml` workflow which:
+- Publishes to npm (with `--tag beta` for pre-releases)
+- Generates the changelog from labeled PRs
+- Creates a GitHub Release
+
+### 7. Verify Release
+
+After pushing the tag, check that:
+1. The GitHub Actions workflow started
+2. The npm package was published
+3. The GitHub Release was created with the changelog

--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -7,7 +7,7 @@ on:
 
 permissions:
   id-token: write  # Required for OIDC trusted publishing
-  contents: read
+  contents: write  # Required to create GitHub releases
 
 jobs:
   publish:
@@ -18,6 +18,8 @@ jobs:
     
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Required for changelog generation
       
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -25,8 +27,31 @@ jobs:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
       
+      - name: Extract version from tag
+        id: version
+        run: |
+          TAG_NAME="${{ github.ref_name }}"
+          VERSION="${TAG_NAME#cli-v}"
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "Extracted version: ${VERSION}"
+      
+      - name: Determine pre-release status
+        id: prerelease
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          # Check for pre-release suffixes: -alpha, -beta, -rc
+          if [[ "$VERSION" =~ -(alpha|beta|rc) ]]; then
+            echo "is_prerelease=true" >> $GITHUB_OUTPUT
+            echo "npm_tag=beta" >> $GITHUB_OUTPUT
+            echo "This is a pre-release version"
+          else
+            echo "is_prerelease=false" >> $GITHUB_OUTPUT
+            echo "npm_tag=latest" >> $GITHUB_OUTPUT
+            echo "This is a stable release version"
+          fi
+      
       - name: Set version from tag
-        run: npm version ${GITHUB_REF_NAME#cli-v} --no-git-tag-version
+        run: npm version ${{ steps.version.outputs.version }} --no-git-tag-version
       
       - name: Install dependencies
         run: npm ci
@@ -38,4 +63,50 @@ jobs:
         run: npm test
       
       - name: Publish to npm
-        run: npm publish --access public
+        run: npm publish --access public --tag ${{ steps.prerelease.outputs.npm_tag }}
+      
+      - name: Generate changelog
+        id: changelog
+        uses: mikepenz/release-changelog-builder-action@v4
+        with:
+          configuration: .github/cli-release-changelog-config.json
+          failOnError: false
+          toTag: ${{ github.ref_name }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Check if release exists
+        id: check_release
+        working-directory: ${{ github.workspace }}
+        run: |
+          RELEASE_EXISTS=$(gh release view "${{ github.ref_name }}" --json id 2>/dev/null || echo "")
+          if [ -n "$RELEASE_EXISTS" ]; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+            echo "Release already exists for tag ${{ github.ref_name }}, skipping"
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+            echo "No existing release found, will create new release"
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Create GitHub Release
+        if: steps.check_release.outputs.exists == 'false'
+        uses: softprops/action-gh-release@v1
+        with:
+          name: CLI ${{ steps.version.outputs.version }}
+          tag_name: ${{ github.ref_name }}
+          body: ${{ steps.changelog.outputs.changelog }}
+          prerelease: ${{ steps.prerelease.outputs.is_prerelease }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Release summary
+        if: steps.check_release.outputs.exists == 'false'
+        working-directory: ${{ github.workspace }}
+        run: |
+          echo "✅ Release created successfully!"
+          echo "Version: ${{ steps.version.outputs.version }}"
+          echo "Pre-release: ${{ steps.prerelease.outputs.is_prerelease }}"
+          echo "npm tag: ${{ steps.prerelease.outputs.npm_tag }}"
+          echo "View release: ${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ github.ref_name }}"


### PR DESCRIPTION
## Summary

Adds changelog generation and GitHub Release visibility for CLI releases, matching the VS Code extension release workflow.

## Changes

- **`.github/cli-release-changelog-config.json`** - Changelog config with npm/npx install instructions
- **`.github/workflows/publish-cli.yml`** - Updated with:
  - Pre-release detection via `-alpha/-beta/-rc` suffix
  - Conditional npm publish tag (`--tag beta` for pre-releases)
  - Changelog generation using `mikepenz/release-changelog-builder-action`
  - GitHub Release creation with `softprops/action-gh-release`
  - Idempotency check (skips if release exists)
- **`.github/prompts/prepare-cli-release.prompt.md`** - Release preparation prompt that:
  - Assesses PRs merged since last `cli-v*` tag
  - Applies `cli` label to qualifying PRs (no need to remember during development)
  - Ensures category labels are applied
  - Generates changelog preview
- **`.github/copilot-instructions.md`** - Documents the `cli` label

## npm Pre-release Behavior

- Stable versions: `npm publish --access public` (publishes to `latest`)
- Pre-release versions: `npm publish --access public --tag beta` (publishes to `beta`)
- Users install stable with `npm install @paw-workflow/cli`
- Users opt-in to pre-releases with `npm install @paw-workflow/cli@beta`