### PR TITLE
[Planning-Only Final PR Pause Fix] Fix milestone evaluation

### DIFF
--- a/agents/PAW.agent.md
+++ b/agents/PAW.agent.md
@@ -39,6 +39,7 @@ Stage boundaries:
 - Planning PR created (PRs strategy)
 - Phase PR created (PRs strategy) or push complete (local strategy)
 - All phases complete
+- paw-pr complete (Final PR created)
 
 The transition skill returns `pause_at_milestone`. If `true`, STOP and wait for user. This is how milestone pauses happen—without the transition call, you will skip pauses.
 

--- a/skills/paw-transition/SKILL.md
+++ b/skills/paw-transition/SKILL.md
@@ -52,16 +52,24 @@ Use the Mandatory Transitions table:
 - plan-review passes → implement (Phase 1)
 - phase N complete → phase N+1
 - all phases complete → final-pr
+- paw-pr complete → workflow complete
 
-**Milestones** (require pause check): Spec.md complete, ImplementationPlan.md complete, Phase PR completion, Final PR
+**Stage-to-milestone mapping** (determines which milestone is reached at each boundary):
+
+| Stage Boundary | Milestone Reached |
+|----------------|-------------------|
+| spec-review passes | Spec.md complete |
+| plan-review passes | ImplementationPlan.md complete |
+| phase N complete (not last) | Phase completion |
+| all phases complete | Phase completion (last phase) |
+| paw-pr complete | Final PR |
 
 **Determine pause_at_milestone**:
-- If at a milestone AND Review Policy ∈ {`always`, `milestones`}: set `pause_at_milestone = true`
+- If Review Policy ∈ {`always`, `milestones`}: pause at ALL milestones
 - If Review Policy = `planning-only`:
-  - If milestone is Spec.md, ImplementationPlan.md, or Final PR: set `pause_at_milestone = true`
-  - If milestone is Phase PR/phase completion: set `pause_at_milestone = false`
-- If Review Policy = `never`: set `pause_at_milestone = false`
-- If not at a milestone: set `pause_at_milestone = false`
+  - Spec.md, ImplementationPlan.md, Final PR: `pause_at_milestone = true`
+  - Phase completion (including last phase): `pause_at_milestone = false`
+- If Review Policy = `never`: `pause_at_milestone = false`
 
 **Determine session_action**:
 - If crossing a stage boundary AND Session Policy = `per-stage`: set `session_action = new_session`


### PR DESCRIPTION
## Summary

Fixes a bug where the `planning-only` review policy incorrectly paused before Final PR creation instead of after.

Fixes #197

## Root Cause

The `paw-transition` skill was treating the "all phases complete → final-pr" stage boundary as if it were the "Final PR" milestone. However:
- "all phases complete" = last phase completion (should NOT pause for planning-only)
- "Final PR" = PR actually created (SHOULD pause for planning-only)

## Changes

**`skills/paw-transition/SKILL.md`**:
- Added explicit stage-to-milestone mapping table
- "all phases complete" now correctly maps to "Phase completion (last phase)"
- Added "paw-pr complete" stage boundary for actual Final PR milestone

**`agents/PAW.agent.md`**:
- Added "paw-pr complete (Final PR created)" to Stage Boundary Rule

## Behavior After Fix

For `planning-only` policy:
- ✅ Auto-proceed from "all phases complete" to `paw-pr`
- ✅ Pause after Final PR is created (at "paw-pr complete" boundary)

Other policies unchanged.

## Testing

- [x] Skill lint passes
- [x] Agent lint passes
- [x] Project lint passes

---

🐾 Generated with [PAW](https://github.com/lossyrob/phased-agent-workflow)