### PR TITLE
docs: revamp README to lead with CLI quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,11 @@ npx @paw-workflow/cli install copilot
 This installs PAW agents and skills to your [GitHub Copilot CLI](https://github.com/github/copilot-cli). Then start a workflow:
 
 ```bash
-copilot
+copilot --agent PAW          # Implementation workflow
+copilot --agent PAW-Review   # PR review workflow
 ```
 
-Use `/agent` to select **PAW** for implementation workflows or **PAW Review** for PR reviews.
+Or use `/agent` inside your session to switch agents.
 
 **Requirements**: Node.js 18+ and [GitHub Copilot CLI](https://github.com/github/copilot-cli) installed.
 


### PR DESCRIPTION
## Summary

Reorients the README to emphasize GitHub Copilot CLI as the primary way to use PAW.

## Changes

- **New 'Try It Now' section** at the top with the `npx` command front and center
- **'Two Platforms' table** showing CLI vs VS Code options side-by-side
- **Reorganized Requirements** to list CLI first as recommended
- **Consolidated VS Code Extension section** into a more compact format
- **Streamlined overall structure** for a CLI-first experience

Anyone landing on the page now immediately sees how to try PAW with the CLI.