### PR TITLE
docs: align documentation with README messaging

### DIFF
--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -4,66 +4,70 @@ This guide will help you get up and running with **Phased Agent Workflow (PAW)**
 
 ## Prerequisites
 
-Before you begin, ensure you have:
-
-- **VS Code** with GitHub Copilot installed and active
 - **Git repository** for your project
-- One of the following platform integrations (authenticated and configured):
-    - **GitHub** with GitHub MCP Tools
-    - **Azure DevOps** with Azure DevOps MCP Tools
+- One of:
+    - [GitHub Copilot CLI](https://github.com/github/copilot-cli) + Node.js 18+
+    - VS Code with GitHub Copilot
 
-## Quick Install
+## Installation
+
+### Option 1: Copilot CLI (Recommended)
+
+```bash
+npx @paw-workflow/cli install copilot
+```
+
+Then start a workflow:
+
+```bash
+copilot --agent PAW
+```
+
+### Option 2: VS Code Extension
 
 1. **Download** the latest `.vsix` from the [Releases page](https://github.com/lossyrob/phased-agent-workflow/releases)
+2. **Install** via Command Palette: `Extensions: Install from VSIX...`
+3. Run `PAW: New PAW Workflow` to start
 
-2. **Install** in VS Code using one of these methods:
-    - Command Palette: `Extensions: Install from VSIX...`
-    - Command line: `code --install-extension paw-workflow-X.X.X.vsix`
-
-3. **Configure MCP Server** (Recommended): Set up the [GitHub MCP Server](https://github.com/modelcontextprotocol/servers/tree/main/src/github) or [Azure DevOps MCP Server](https://github.com/microsoft/azure-devops-mcp-server) in VS Code for optimal agent integration. See the [MCP Server Setup Guide](https://modelcontextprotocol.io/quickstart/user) for configuration instructions.
+Both options use the same PAW agents and skills—choose based on your preferred interface.
 
 ## Starting Your First Workflow
 
-### Create a New PAW Workflow
+### With Copilot CLI
+
+```bash
+copilot --agent PAW
+# Then tell PAW what you want to build, e.g.:
+# "Start a new workflow for adding user authentication"
+```
+
+### With VS Code
 
 1. Open the Command Palette (`Ctrl+Shift+P` / `Cmd+Shift+P`)
 2. Type **"PAW: New PAW Workflow"**
-3. Enter the issue or work item URL (optional—press Enter to skip)
-4. Enter a branch name (optional—press Enter to auto-derive from issue or description)
-5. Select your workflow mode and review strategy
+3. Enter the issue URL or description
+4. Select your workflow mode
 
-PAW will create your workflow structure automatically:
+PAW will create your workflow structure:
 
 ```
 .paw/work/<feature-slug>/
   WorkflowContext.md    # Your workflow parameters
 ```
 
-### Check Workflow Status
-
-At any time during a workflow:
-
-1. Open the Command Palette (`Ctrl+Shift+P` / `Cmd+Shift+P`)
-2. Type **"PAW: Get Work Status"**
-3. Select your work item or choose "Auto-detect from context"
-
-The Status Agent will analyze your progress and provide actionable next-step recommendations.
-
 ## Workflow Overview
 
-PAW guides you through structured phases:
+PAW guides you through structured stages:
 
-1. **Specification** — Turn rough ideas into testable requirements
+1. **Specification** — Turn ideas into testable requirements
 2. **Research** — Understand the codebase and system behavior
-3. **Planning** — Create detailed implementation plans
-4. **Implementation** — Execute plans with automated verification
-5. **Documentation** — Generate comprehensive docs
-6. **Final PR** — Open the pull request to main
+3. **Planning** — Create phased implementation plans
+4. **Implementation** — Execute plans with optional PR review at each phase
 
-Each phase produces durable artifacts that feed the next, ensuring nothing falls through the cracks.
+Each stage produces durable artifacts that accumulate context and feed the next.
 
 ## Next Steps
 
-- [Workflow Modes](workflow-modes.md) — Learn about Full, Minimal, and Custom modes
+- [Workflow Modes](workflow-modes.md) — Learn about Full and Minimal modes
 - [Two Workflows](two-workflows.md) — Understand Implementation vs Review workflows
-- [Specification](../specification/index.md) — Deep dive into the PAW specification
+- [CLI Installation](cli-installation.md) — Detailed CLI setup and management

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,28 +2,39 @@
 
 <div align="center" style="margin: 2em 0;">
 <img src="https://raw.githubusercontent.com/lossyrob/phased-agent-workflow/main/img/paw-logo.png" alt="PAW Logo" width="200"/>
+<h3>Context-Driven Development for GitHub Copilot</h3>
 </div>
 
-**PAW** is a VS Code extension that coordinates multi-stage AI agent workflows for feature implementation and code review. It transforms complex development tasks into structured, verifiable phases with clear handoffs between specialized agents.
+**PAW** enables **Context-Driven Development**—a practice where AI agents build understanding through structured research and planning phases before writing code. Each phase produces durable artifacts that accumulate context and feed the next phase.
 
 ## Why PAW?
 
-Building features with AI coding agents is powerful, but without structure, it's easy to lose track of decisions, introduce inconsistencies, or struggle to iterate when things go wrong.
+AI agents work best when given clear, accumulated context rather than open-ended prompts. Without structure, it's easy to lose track of decisions, introduce inconsistencies, or struggle to iterate when things go wrong.
 
 PAW provides:
 
-- **Structured phases** — Move from spec to implementation to docs with clear checkpoints
-- **Durable artifacts** — Every decision is captured in version-controlled Markdown
-- **Rewindability** — Fix upstream problems and regenerate downstream work
-- **Human oversight** — You approve specs, plans, and PRs at critical decision points
-- **Two workflows** — Build new features OR review existing pull requests
+- **PR-integrated workflow** — Every implementation phase can create a PR for human review
+- **Dedicated research phases** — Build documented understanding before planning begins
+- **Rewindable at any layer** — Artifacts are checkpoints; restart from spec, plan, or any phase
+- **AI-assisted code review** — Review workflow helps human reviewers by surfacing impacts and drafting feedback
+- **Extensible skills architecture** — Compact orchestrator agents delegate to specialized skills
 
 ## Quick Start
 
-1. [Install the extension](guide/index.md#quick-install) from GitHub Releases
-2. Open a Git repository in VS Code
+### Copilot CLI (Recommended)
+
+```bash
+npx @paw-workflow/cli install copilot
+copilot --agent PAW
+```
+
+### VS Code Extension
+
+1. [Download the extension](https://github.com/lossyrob/phased-agent-workflow/releases) from GitHub Releases
+2. Install via `Extensions: Install from VSIX...`
 3. Run `PAW: New PAW Workflow` from the Command Palette
-4. Follow the guided workflow through each stage
+
+Both platforms use the same PAW agents and skills.
 
 [Get Started →](guide/index.md){ .md-button .md-button--primary }
 
@@ -31,10 +42,10 @@ PAW provides:
 
 ### Implementation Workflow
 
-Build features from scratch through structured phases:
+Build features from issue to merged PR through four stages:
 
 ```
-Issue → Specification → Research → Planning → Implementation → Documentation → Final PR
+Specification → Research → Planning → Implementation
 ```
 
 **Use for:** New features, enhancements, refactors, and bug fixes.
@@ -43,10 +54,10 @@ Issue → Specification → Research → Planning → Implementation → Documen
 
 ### Review Workflow
 
-Thoroughly review pull requests with evidence-based feedback:
+Assist human reviewers with evidence-based feedback:
 
 ```
-PR → Understanding → Evaluation → Feedback Generation
+Understanding → Evaluation → Feedback
 ```
 
 **Use for:** Reviewing any PR—especially large or poorly-documented ones.
@@ -57,20 +68,20 @@ PR → Understanding → Evaluation → Feedback Generation
 
 | Concept | Description |
 |---------|-------------|
-| **Stages** | Workflow milestones (Specification, Planning, Implementation, etc.) |
+| **Stages** | Workflow milestones (Specification, Planning, Implementation) |
 | **Phases** | Discrete implementation chunks within the Implementation stage |
-| **Agents** | Specialized AI chat modes that handle specific stages |
+| **Skills** | Specialized capabilities loaded by orchestrator agents |
 | **Artifacts** | Durable Markdown documents produced at each stage |
 
 ## Documentation
 
 - **[Getting Started](guide/index.md)** — Install PAW and start your first workflow
-- **[Workflow Modes](guide/workflow-modes.md)** — Configure Full, Minimal, or Custom modes
+- **[Workflow Modes](guide/workflow-modes.md)** — Configure Full or Minimal modes
 - **[Specification](specification/index.md)** — Deep dive into PAW's workflow design
-- **[Agents Reference](reference/agents.md)** — All PAW agents and their purposes
+- **[Reference](reference/agents.md)** — PAW agents and skills
 
 ## Requirements
 
-- VS Code with GitHub Copilot
+- [GitHub Copilot CLI](https://github.com/github/copilot-cli) or VS Code with GitHub Copilot
+- Node.js 18+ (for CLI installation)
 - Git repository
-- GitHub MCP Tools or Azure DevOps MCP Tools (recommended)

--- a/paw-specification.md
+++ b/paw-specification.md
@@ -1,19 +1,19 @@
 ## Overview
 
-The **Phased Agent Workflow (PAW)** streamlines development of GitHub Copilot chat modes and features by moving work through **staged, reviewable milestones** with **clear artifacts**. PAW separates the lifecycle into **workflow stages** (Specification → Planning → Implementation → Documentation → Integration) and, inside the Implementation stage, **implementation phases** (Phase 1…N) that ship incremental, reviewable PRs.
+**Phased Agent Workflow (PAW)** enables **Context-Driven Development**—a practice where AI agents build understanding through structured research and planning phases before writing code. Each phase produces durable artifacts that accumulate context and feed the next phase.
+
+PAW separates the lifecycle into **workflow stages** (Specification → Research → Planning → Implementation) and, inside the Implementation stage, **implementation phases** (Phase 1…N) that ship incremental, reviewable PRs.
 
 **Key properties**
 
+* **Context-Driven** – Research and planning phases build documented understanding before code is written.
 * **Traceable** – Every stage produces durable Markdown artifacts committed to Git and reviewed via PRs.
-* **Rewindable** – Any stage can restart. If you see the agents are implementing incorrectly, you can always go back to the spec or plan and fix it, and then re-run downstream stages.
-* **Agentic** – Purpose‑built chat modes (“agents”) own the work of each stage.
-* **Human‑in‑the‑loop** – Humans approve specs/plans, review PRs, and decide when to rewind.
-* **Consistent surfaces** – Issues and PRs stay in sync via a lightweight Status agent.
+* **Rewindable** – Any stage can restart. If context drifts or requirements change, go back to spec or plan and re-run downstream stages.
+* **PR-Integrated** – Every implementation phase can create a PR for human review, fitting into real team code review workflows.
+* **Human-in-the-loop** – Humans approve specs/plans, review PRs, and decide when to rewind.
 
 > **Terminology note:** In PAW, **Stages** refer to workflow milestones (e.g., Specification Stage). Within the **Implementation Stage**, work is split into **Implementation Phases** (Phase 1, Phase 2, …) to keep PRs small and reviewable.
 > *PAW is staged, and its implementation is phased.*
-
----
 
 ## Workflow Modes
 


### PR DESCRIPTION
## Summary

Updates documentation to align with the recently overhauled README messaging.

## Changes

### docs/index.md
- Add 'Context-Driven Development for GitHub Copilot' tagline
- Rewrite intro with Context-Driven Development framing
- CLI-first Quick Start (npx command before VS Code)
- Platform parity statement
- Simplified 4-stage Implementation workflow
- Updated Key Benefits to match README
- Remove MCP jargon from Requirements

### docs/guide/index.md
- CLI-first installation (Option 1: Copilot CLI)
- Remove MCP prerequisites
- Simplified workflow overview (4 stages)
- Platform parity note

### paw-specification.md
- Add Context-Driven Development to Overview
- Updated Key Properties (Context-Driven, PR-Integrated)
- Simplified stage list

## Alignment with README

All three files now use consistent:
- 'Context-Driven Development' philosophy
- 4-stage Implementation model (Spec → Research → Planning → Implementation)
- 3-stage Review model (Understanding → Evaluation → Feedback)
- CLI-first positioning with platform parity
- No MCP jargon in user-facing docs