### PR TITLE
feat(cli): show quickstart guide on fresh install

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ copilot --agent PAW-Review   # PR review workflow
 
 Or use `/agent` inside your session to switch agents.
 
+Upgrade with `npx @paw-workflow/cli upgrade`, uninstall with `npx @paw-workflow/cli uninstall`.
+
 **Requirements**: Node.js 18+ and [GitHub Copilot CLI](https://github.com/github/copilot-cli) installed.
 
 ---

--- a/cli/lib/commands/install.js
+++ b/cli/lib/commands/install.js
@@ -98,6 +98,23 @@ export async function installCommand(target, flags = {}) {
   const skillCount = readdirSync(distSkillsDir, { withFileTypes: true })
     .filter(e => e.isDirectory()).length;
   
-  console.log(`\nInstalled ${agentCount} agents and ${skillCount} skills to ~/.copilot/`);
-  console.log('Manifest written to ~/.paw/copilot-cli/manifest.json');
+  console.log(`\n✓ Installed ${agentCount} agents and ${skillCount} skills to ~/.copilot/`);
+
+  if (!hasExistingFiles) {
+    console.log(`
+🚀 Quick Start
+  Start a workflow:    copilot --agent PAW
+  Review a PR:         copilot --agent PAW-Review
+  Or use /agent inside any copilot session to switch agents.
+
+💡 Try saying:
+  "I want to add a feature for..."
+  "Help me refactor the auth module"
+  "Review PR #100" (with PAW-Review agent)
+
+📦 Manage your installation:
+  npx @paw-workflow/cli list       Show installed version
+  npx @paw-workflow/cli upgrade    Check for updates
+  npx @paw-workflow/cli uninstall  Cleanly remove PAW`);
+  }
 }

--- a/cli/test/install.test.js
+++ b/cli/test/install.test.js
@@ -89,6 +89,51 @@ describe('CLI entry point', () => {
   });
 });
 
+describe('install output', () => {
+  test('fresh install shows quickstart guide', async () => {
+    const { execSync } = await import('child_process');
+    const { mkdirSync } = await import('fs');
+    const cliPath = join(import.meta.dirname, '..', 'bin', 'paw.js');
+    const freshHome = join(TEST_DIR, 'fresh-install');
+    mkdirSync(freshHome, { recursive: true });
+    
+    const output = execSync(`node ${cliPath} install copilot`, {
+      encoding: 'utf-8',
+      env: { ...process.env, HOME: freshHome },
+    });
+    
+    assert.ok(output.includes('Quick Start'), 'should show Quick Start section');
+    assert.ok(output.includes('copilot --agent PAW'), 'should show PAW agent command');
+    assert.ok(output.includes('copilot --agent PAW-Review'), 'should show PAW-Review command');
+    assert.ok(output.includes('/agent'), 'should mention /agent');
+    assert.ok(output.includes('Try saying'), 'should show Try saying section');
+    assert.ok(output.includes('uninstall'), 'should mention uninstall');
+  });
+
+  test('repeat install does not show quickstart guide', async () => {
+    const { execSync } = await import('child_process');
+    const { mkdirSync } = await import('fs');
+    const cliPath = join(import.meta.dirname, '..', 'bin', 'paw.js');
+    const upgradeHome = join(TEST_DIR, 'upgrade-install');
+    mkdirSync(upgradeHome, { recursive: true });
+    
+    // First install
+    execSync(`node ${cliPath} install copilot`, {
+      encoding: 'utf-8',
+      env: { ...process.env, HOME: upgradeHome },
+    });
+    
+    // Second install (upgrade) with --force to skip prompt
+    const output = execSync(`node ${cliPath} install copilot --force`, {
+      encoding: 'utf-8',
+      env: { ...process.env, HOME: upgradeHome },
+    });
+    
+    assert.ok(!output.includes('Quick Start'), 'should not show quickstart on repeat install');
+    assert.ok(output.includes('Installed'), 'should still show install summary');
+  });
+});
+
 describe('list command', () => {
   test('shows not installed when no manifest', async () => {
     const { execSync } = await import('child_process');


### PR DESCRIPTION
## Summary

After a fresh `npx @paw-workflow/cli install copilot`, users now see a quickstart guide with:

- **Start commands** — `copilot --agent PAW` and `copilot --agent PAW-Review`
- **Example prompts** — implementation-focused examples + one review example
- **Management commands** — list, upgrade, uninstall
- **`/agent` mention** — for switching agents mid-session

Repeat installs (upgrades) show only the install count summary, keeping the output clean for existing users.

### README

Added a one-liner in "Try It Now" with upgrade/uninstall commands so fence-sitters can see it's easy to back out.

### Tests

Two new tests verify:
- Fresh install shows quickstart guide (checks key sections)
- Repeat install does NOT show quickstart guide

All 16 tests pass.

### Labels
- `enhancement`
- `cli`