### PR TITLE
fix: update CLI release label model and changelog tag resolver

### DIFF
--- a/.github/cli-release-changelog-config.json
+++ b/.github/cli-release-changelog-config.json
@@ -29,7 +29,8 @@
     "ignore",
     "wontfix",
     "duplicate",
-    "invalid"
+    "invalid",
+    "vscode"
   ],
   "sort": {
     "order": "ASC",
@@ -39,5 +40,11 @@
   "pr_template": "- #{{TITLE}} (#{{NUMBER}})",
   "empty_template": "No CLI changes in this release",
   "max_pull_requests": 200,
-  "max_back_track_time_days": 365
+  "max_back_track_time_days": 365,
+  "tag_resolver": {
+    "method": "semver",
+    "filter": {
+      "pattern": "cli-v(.*)"
+    }
+  }
 }

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -65,9 +65,13 @@ All pull requests to `main` must be labeled with one of the following category l
 
 ### CLI Label
 
-PRs that affect CLI code (`cli/` directory, `publish-cli.yml`, etc.) should also have the `cli` label. This label is **applied at release-prep time** using the `prepare-cli-release.prompt.md` prompt—you don't need to remember to add it during development. The prompt assesses each PR and applies the label if it affects CLI code.
+PRs that **only** affect CLI-specific code (`cli/` directory, `publish-cli.yml`, etc.) should have the `cli` label. These won't appear in the VS Code extension changelog.
 
-VS Code extension PRs don't need a special label (the extension changelog includes all PRs to main).
+### VS Code Label
+
+PRs that **only** affect VS Code extension code should have the `vscode` label. These are excluded from the CLI release changelog.
+
+PRs that touch agents, skills, prompts, or shared code don't need a platform label—they're included in both changelogs by default. Platform labels are applied at release-prep time using `prepare-cli-release.prompt.md`.
 
 IMPORTANT: **PAW Architecture Philosophy** - tools provide procedural operations, agents provide decision-making logic and reasoning. Rely on agents to use reasoning and logic over hardcoding procedural steps into tools.
 

--- a/.github/prompts/prepare-cli-release.prompt.md
+++ b/.github/prompts/prepare-cli-release.prompt.md
@@ -1,15 +1,25 @@
 # Prepare CLI Release
 
-This prompt guides the GitHub Copilot agent through preparing a CLI release by identifying CLI-related PRs, labeling them appropriately, and creating the release tag.
+This prompt guides the agent through preparing a CLI release by identifying PRs, ensuring labels, and creating the release tag.
 
 ## Overview
 
 You will:
-1. Identify PRs merged since the last CLI release
-2. Assess which PRs affect CLI code and apply the `cli` label
-3. Ensure all CLI PRs have category labels
+1. Identify PRs merged to `main` since the last CLI release
+2. Exclude any VS Code-only PRs (label with `vscode`)
+3. Ensure all included PRs have category labels
 4. Generate a changelog preview
 5. Create and push the release tag
+
+## Label Model
+
+The CLI installs agents, skills, and CLI code. Most PRs are relevant to the CLI release.
+
+- **No platform label** — Relevant to both CLI and VS Code (default for most PRs)
+- **`cli`** — CLI-only changes (not in VS Code extension changelog)
+- **`vscode`** — VS Code-only changes (excluded from CLI changelog)
+
+The changelog builder automatically excludes PRs labeled `vscode`.
 
 ## Prerequisites
 
@@ -20,71 +30,40 @@ You will:
 
 ### 1. Determine Release Version
 
-First, check the latest CLI release tags to determine the next version by listing recent tags matching `cli-v*`.
+Check the latest CLI release tags (`cli-v*`) to determine the next version.
 
-Follow semantic versioning conventions:
-- **Stable releases**: `cli-v1.0.0`, `cli-v1.0.1`, `cli-v1.1.0`
-- **Pre-releases**: `cli-v1.0.0-alpha.1`, `cli-v1.0.0-beta.1`, `cli-v1.0.0-rc.1`
-
-Pre-release versions are published to the `beta` npm dist-tag and won't be installed by default.
-
-Choose the appropriate next version based on the changes:
-- **Patch release** (1.0.0 → 1.0.1): Bug fixes and minor updates
-- **Minor release** (1.0.0 → 1.1.0): New features, backward compatible
-- **Major release** (1.0.0 → 2.0.0): Breaking changes
-- **Pre-release** (1.0.0 → 1.1.0-beta.1): Testing before stable release
+Semantic versioning:
+- **Patch** (0.0.3 → 0.0.4): Bug fixes and minor updates
+- **Minor** (0.0.3 → 0.1.0): New features, backward compatible
+- **Major** (0.0.3 → 1.0.0): Breaking changes
+- **Pre-release** (0.0.4-beta.1): Published to `beta` npm dist-tag
 
 Ask the user to confirm the version number before proceeding.
 
 ### 2. Identify PRs for Release
 
-Find the last `cli-v*` release tag and its commit date. Then search for all merged PRs **that target the main branch** since that date.
+Find the last `cli-v*` release tag and its date. Search for all merged PRs **targeting `main`** since that date.
 
-**IMPORTANT:** Only include PRs where the base/target branch is `main`. Exclude PRs that targeted feature branches.
+Exclude PRs that targeted feature branches (not `main`).
 
-### 3. Assess and Label CLI PRs
+### 3. Label PRs
 
-For each PR merged since the last release, determine if it affects CLI code. A PR should receive the `cli` label if it includes changes to:
+For each PR, review its changed files and apply labels:
 
-- `cli/` directory (source code, tests, scripts)
-- `.github/workflows/publish-cli.yml`
-- `.github/cli-release-changelog-config.json`
-- `.github/prompts/prepare-cli-release.prompt.md`
-- CLI-related documentation in `docs/` that specifically covers CLI usage
+**Platform labels** (apply when needed):
+- Add `vscode` if the PR **only** affects VS Code extension code (e.g., `.vsix` packaging, VS Code-specific UI, extension manifest) with no changes to agents, skills, CLI, or shared code
+- Add `cli` if the PR **only** affects CLI-specific code (`cli/` directory, `publish-cli.yml`, CLI-specific docs) with no changes to agents, skills, or shared code
+- Leave unlabeled (no platform label) if the PR touches agents, skills, prompts, shared docs, or anything installed by both platforms
 
-**Labeling workflow:**
-1. Review each PR's changed files
-2. If the PR affects CLI code (per criteria above), add the `cli` label
-3. If the PR already has a category label (`enhancement`, `bug`, `documentation`, `maintenance`), keep it
-4. If the PR lacks a category label, determine the appropriate one based on the PR content and add it
+**Category labels** (every PR needs one):
+- `enhancement` — New features
+- `bug` — Bug fixes
+- `documentation` — Documentation changes
+- `maintenance` — Refactoring, CI/CD, dependency updates
 
-**Category label guidelines:**
-- `enhancement` - New features, major enhancements
-- `bug` - Bug fixes, error corrections
-- `documentation` - README updates, documentation improvements
-- `maintenance` - Refactoring, code cleanup, dependency updates, CI/CD changes
+### 4. Generate Changelog Preview
 
-Continue until all CLI-affecting PRs have both the `cli` label and a category label.
-
-### 4. Verify All CLI PRs Are Labeled
-
-Re-check that all CLI PRs now have:
-1. The `cli` label
-2. One of the category labels
-
-If any are still missing labels, repeat step 3.
-
-### 5. Generate Changelog Preview
-
-Generate a changelog preview organized by label category. **Only include PRs that have the `cli` label.**
-
-Search for merged PRs since the last release filtered by the `cli` label AND each category label:
-- `cli` + `enhancement` for Features
-- `cli` + `bug` for Bug Fixes
-- `cli` + `documentation` for Documentation
-- `cli` + `maintenance` for Maintenance
-
-Format the output as a complete changelog:
+Generate a changelog from all PRs since the last release, **excluding** any labeled `vscode`. Organize by category:
 
 ```
 ## 🚀 Features
@@ -102,22 +81,19 @@ Format the output as a complete changelog:
 
 Present this changelog to the user for review.
 
-### 6. Create and Push Tag
+### 5. Create and Push Tag
 
 After the user approves:
 
-1. Ensure you're on the `main` branch with a clean working directory
+1. Ensure you're on `main` with a clean working directory
 2. Create the annotated tag: `git tag -a cli-v<version> -m "CLI release <version>"`
 3. Push the tag: `git push origin cli-v<version>`
 
-The tag push will trigger the `publish-cli.yml` workflow which:
-- Publishes to npm (with `--tag beta` for pre-releases)
-- Generates the changelog from labeled PRs
-- Creates a GitHub Release
+The tag push triggers `publish-cli.yml` which publishes to npm and creates a GitHub Release.
 
-### 7. Verify Release
+### 6. Verify Release
 
-After pushing the tag, check that:
+Check that:
 1. The GitHub Actions workflow started
 2. The npm package was published
 3. The GitHub Release was created with the changelog


### PR DESCRIPTION
## Summary

Fixes two issues with the CLI release process:

### 1. Inverted label model

**Before**: PRs needed a `cli` label to be included in the CLI changelog. But the CLI installs agents, skills, and CLI code — most PRs are relevant.

**After**: All PRs are included by default. Only PRs labeled `vscode` (VS Code extension-only) are excluded.

| Label | Meaning |
|-------|---------|
| *(none)* | Relevant to both CLI and VS Code (default) |
| `cli` | CLI-only (excluded from VS Code extension changelog) |
| `vscode` | VS Code-only (excluded from CLI changelog) |

### 2. Changelog tag resolver

The `release-changelog-builder-action` was auto-detecting the previous tag as `v0.10.0` instead of `cli-v0.0.3`, causing the 0.0.4 changelog to only show 1 PR instead of 14. Added `tag_resolver` with `cli-v(.*)` pattern so it only considers CLI release tags.

### Files changed

- `.github/prompts/prepare-cli-release.prompt.md` — rewritten with new label model
- `.github/cli-release-changelog-config.json` — added `vscode` to `ignore_labels`, added `tag_resolver`
- `.github/copilot-instructions.md` — updated label documentation