### PR TITLE
fix(cli): read version from package.json instead of hardcoded value

### DIFF
--- a/cli/bin/paw.js
+++ b/cli/bin/paw.js
@@ -4,8 +4,7 @@ import { installCommand } from '../lib/commands/install.js';
 import { listCommand } from '../lib/commands/list.js';
 import { uninstallCommand } from '../lib/commands/uninstall.js';
 import { upgradeCommand } from '../lib/commands/upgrade.js';
-
-const VERSION = '0.0.1';
+import { VERSION } from '../lib/version.js';
 
 const HELP = `
 paw - Phased Agent Workflow CLI

--- a/cli/lib/commands/install.js
+++ b/cli/lib/commands/install.js
@@ -8,8 +8,7 @@ import {
   getDistSkillsDir,
 } from '../paths.js';
 import { readManifest, writeManifest, createManifest } from '../manifest.js';
-
-const VERSION = '0.0.1';
+import { VERSION } from '../version.js';
 
 const SUPPORTED_TARGETS = ['copilot'];
 

--- a/cli/lib/version.js
+++ b/cli/lib/version.js
@@ -1,0 +1,6 @@
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+const pkg = require('../package.json');
+
+export const VERSION = pkg.version;

--- a/cli/test/install.test.js
+++ b/cli/test/install.test.js
@@ -61,7 +61,7 @@ describe('CLI entry point', () => {
     
     const output = execSync(`node ${cliPath} --version`, { encoding: 'utf-8' });
     
-    assert.match(output.trim(), /^\d+\.\d+\.\d+$/);
+    assert.match(output.trim(), /^\d+\.\d+\.\d+/);
   });
   
   test('install without target shows error', async () => {
@@ -131,6 +131,42 @@ describe('install output', () => {
     
     assert.ok(!output.includes('Quick Start'), 'should not show quickstart on repeat install');
     assert.ok(output.includes('Installed'), 'should still show install summary');
+  });
+
+  test('manifest records version from package.json', async () => {
+    const { execSync } = await import('child_process');
+    const { mkdirSync, readFileSync } = await import('fs');
+    const cliPath = join(import.meta.dirname, '..', 'bin', 'paw.js');
+    const versionHome = join(TEST_DIR, 'version-check');
+    mkdirSync(versionHome, { recursive: true });
+
+    const pkgJson = JSON.parse(readFileSync(join(import.meta.dirname, '..', 'package.json'), 'utf-8'));
+
+    execSync(`node ${cliPath} install copilot`, {
+      encoding: 'utf-8',
+      env: { ...process.env, HOME: versionHome },
+    });
+
+    // Verify via list command output
+    const listOutput = execSync(`node ${cliPath} list`, {
+      encoding: 'utf-8',
+      env: { ...process.env, HOME: versionHome },
+    });
+
+    assert.ok(listOutput.includes(`PAW v${pkgJson.version}`),
+      `manifest version should be ${pkgJson.version}, got: ${listOutput}`);
+  });
+
+  test('version flag matches package.json', async () => {
+    const { execSync } = await import('child_process');
+    const { readFileSync } = await import('fs');
+    const cliPath = join(import.meta.dirname, '..', 'bin', 'paw.js');
+
+    const pkgJson = JSON.parse(readFileSync(join(import.meta.dirname, '..', 'package.json'), 'utf-8'));
+    const output = execSync(`node ${cliPath} --version`, { encoding: 'utf-8' });
+
+    assert.strictEqual(output.trim(), pkgJson.version,
+      'CLI --version should match package.json version');
   });
 });
 


### PR DESCRIPTION
## Problem

The CLI had `const VERSION = '0.0.1'` hardcoded in both `bin/paw.js` and `lib/commands/install.js`. This meant:

- The manifest always recorded version `0.0.1`
- `paw upgrade` always thought it needed to upgrade (0.0.1 → latest)
- `paw --version` always showed `0.0.1`

## Fix

Created `cli/lib/version.js` that reads the version from `package.json` at runtime. Both `bin/paw.js` and `install.js` import from there.

The publish workflow already runs `npm version` before build, so `package.json` has the correct version at publish time.