### PR TITLE
feat: Add fleet mode to PAW agent

### DIFF
--- a/agents/PAW.agent.md
+++ b/agents/PAW.agent.md
@@ -9,6 +9,20 @@ You are a workflow orchestrator using a **hybrid execution model**: interactive 
 
 On first request, identify work context from environment (current branch, `.paw/work/` directories) or user input. If no matching WorkflowContext.md exists, load `paw-init` to bootstrap. If resuming existing work, derive TODO state from completed artifacts. Load `paw-workflow` skill for reference documentation (activity tables, artifact structure, PR routing).
 
+**Fleet detection**: If session context contains fleet mode instructions (fleet coordinator systemMessage or dispatch markers), activate Fleet Mode.
+
+## Fleet Mode
+
+PAW becomes a "workflow definer" — emit SQL `todos`/`todo_deps` and **stop**. Fleet dispatches each todo as an independent subagent.
+
+1. Run `paw-init` normally
+2. INSERT pre-planning chain: `spec` → `spec-review` → `code-research` → `planning` → `plan-review` → `expand-phases`
+3. Stop — do not use Hybrid Execution Model
+
+**Expand-phases**: Subagent reads `ImplementationPlan.md`, INSERTs `implement-pN` → `impl-review-pN` → ... → `paw-pr` (include `paw-final-review` when enabled).
+
+**Todo prompts must be self-contained**: skill path (`skills/<name>/SKILL.md`), artifact dir + input files, done criteria, FAIL handling (fix and retry internally).
+
 ## Workflow Rules
 
 ### Mandatory Transitions


### PR DESCRIPTION
## Summary

When dispatched under fleet coordination, PAW switches from workflow executor to workflow definer — emitting SQL `todos` with `todo_deps` dependencies instead of executing activities directly. This ensures mandatory reviews cannot be structurally bypassed when PAW runs as a fleet subagent.

## Changes

**`agents/PAW.agent.md`** (+14 lines):
- Fleet detection check in Initialization section
- New `## Fleet Mode` section with:
  - Pre-planning todo chain (`spec` → `spec-review` → `code-research` → `planning` → `plan-review` → `expand-phases`)
  - Dynamic phase expansion from `ImplementationPlan.md`
  - Self-contained todo prompt rules for subagent execution

## Design Decisions

- **Eager expansion**: All phases emitted at once (expand-phases reads plan, inserts all implementation todos)
- **FAIL handling**: Reviews fix-and-retry internally within the todo prompt (don't yield as failed)
- **Detection**: Explicit fleet marker detection (fleet coordinator systemMessage or dispatch markers)
- **Token discipline**: 2437 → 2643 tokens (+206, 8.5% increase — justified for major new capability)

## Backward Compatibility

Purely additive — no existing direct-mode behavior is modified. Fleet mode only activates when fleet instructions are detected in session context.

## Validation

- `./scripts/lint-prompting.sh agents/PAW.agent.md` ✅
- `npm run lint` ✅
- POC validation in `poc/sdk/src/` confirmed fleet + PAW agent composition works via SDK

Closes #228