### PR TITLE
fix: remove unsupported metadata field from paw-review-github skill

### DIFF
--- a/skills/paw-review-github/SKILL.md
+++ b/skills/paw-review-github/SKILL.md
@@ -1,11 +1,6 @@
 ---
 name: paw-review-github
 description: Posts finalized review comments to GitHub as a pending review after critique iteration is complete.
-metadata:
-  type: activity
-  artifacts: none
-  updates: ReviewComments.md
-  stage: output
 ---
 
 # PAW Review GitHub Skill


### PR DESCRIPTION
Removes the `metadata` frontmatter field from `skills/paw-review-github/SKILL.md` which is not recognized by the Copilot CLI skills parser, causing this warning on skill reload:

```
⚠ The following skills have warnings:
  • paw-review-github/SKILL.md: unknown field ignored: metadata
```

The metadata block (`type`, `artifacts`, `updates`, `stage`) was informational only and not used by any tooling.