### PR TITLE
Fix milestones policy: 'Phase PR completion' → 'Phase completion'

### DIFF
--- a/agents/PAW.agent.md
+++ b/agents/PAW.agent.md
@@ -61,7 +61,7 @@ For PRs strategy, phase branches are required (e.g., `feature/123_phase1`).
 **IMPORTANT**: Review Policy controls HUMAN review pauses only. It does NOT affect automated quality gates (paw-spec-review, paw-plan-review, paw-impl-review). Those are mandatory per the Mandatory Transitions table regardless of Review Policy setting.
 
 - `every-stage`: Pause after every artifact for user confirmation
-- `milestones`: Pause at milestone artifacts only (Spec.md, ImplementationPlan.md, Planning Documents Review completion, Phase PR completion, Final PR); auto-proceed at non-milestones (WorkflowContext.md, SpecResearch.md, CodeResearch.md, Docs.md)
+- `milestones`: Pause at milestone artifacts only (Spec.md, ImplementationPlan.md, Planning Documents Review completion, Phase completion, Final PR); auto-proceed at non-milestones (WorkflowContext.md, SpecResearch.md, CodeResearch.md, Docs.md)
 - `planning-only`: Pause at Spec.md, ImplementationPlan.md, Planning Documents Review completion, and Final PR only; auto-proceed at phase completions (local strategy required)
 - `final-pr-only`: Only pause at final PR — auto-proceed through all intermediate stages
 

--- a/docs/guide/stage-transitions.md
+++ b/docs/guide/stage-transitions.md
@@ -59,7 +59,7 @@ In `milestones` mode, the workflow pauses only at key milestone artifacts:
 - Spec.md (after specification is created)
 - ImplementationPlan.md (after plan is created)
 - Planning Documents Review completion (if enabled)
-- Phase PR completion (after each phase PR is opened)
+- Phase completion (after each implementation phase completes)
 - Final PR creation
 
 **Auto-proceeds at (non-milestone artifacts):**

--- a/docs/reference/agents.md
+++ b/docs/reference/agents.md
@@ -101,7 +101,7 @@ This preserves conversation flow for interactive work while leveraging fresh con
 | Policy | Behavior |
 |--------|----------|
 | `every-stage` | Pause after every artifact is produced |
-| `milestones` | Pause at key artifacts (Spec.md, ImplementationPlan.md, Phase PRs, Final PR) |
+| `milestones` | Pause at key artifacts (Spec.md, ImplementationPlan.md, Phase completion, Final PR) |
 | `planning-only` | Pause at Spec.md, ImplementationPlan.md, and Final PR only; auto-proceed at phases (requires `local` strategy) |
 | `final-pr-only` | Only pause at final PR — auto-proceed through all intermediate stages |
 
@@ -203,7 +203,7 @@ PAW supports four review policies that control when the workflow pauses for huma
 | Policy | Behavior |
 |--------|----------|
 | **every-stage** | Pause after every artifact is produced |
-| **milestones** | Pause at key artifacts (Spec.md, ImplementationPlan.md, Phase PRs, Final PR) |
+| **milestones** | Pause at key artifacts (Spec.md, ImplementationPlan.md, Phase completion, Final PR) |
 | **planning-only** | Pause at Spec.md, ImplementationPlan.md, and Final PR only; auto-proceed at phases (requires `local` strategy) |
 | **final-pr-only** | Only pause at final PR — auto-proceed through all intermediate stages |
 


### PR DESCRIPTION
The `milestones` review policy should pause at phase completion regardless of review strategy (local or PRs). The `paw-transition` skill correctly uses "Phase completion," but three documentation files said "Phase PR completion," causing agents to skip pauses with local strategy.

**Fixed in:**
- `agents/PAW.agent.md` — Review Policy Behavior section
- `docs/guide/stage-transitions.md` — Milestones section  
- `docs/reference/agents.md` — two Review Policy tables

Fixes #243