### PR TITLE
Fix candidate promotion to run before final review, not after

### DIFF
--- a/agents/PAW.agent.md
+++ b/agents/PAW.agent.md
@@ -121,7 +121,7 @@ When `paw-transition` returns `promotion_pending = true` with a `candidates` lis
    - **Promote**: Update candidate to `- [x] [promoted] <desc>` in ImplementationPlan.md. Run `paw-code-research` + `paw-planning` to elaborate into a full phase, then follow standard mandatory transitions (plan-review → implement → impl-review). If research reveals infeasibility, update to `- [x] [not feasible] <desc>` and continue with remaining candidates. User may request a lightweight promote (skip plan-review) for trivial changes.
    - **Skip**: Update candidate to `- [x] [skipped] <desc>` in ImplementationPlan.md
    - **Defer**: Update candidate to `- [x] [deferred] <desc>` in ImplementationPlan.md
-3. After all candidates resolved: proceed to `paw-pr`
+3. After all candidates resolved: proceed to `paw-final-review` (if enabled) or `paw-pr` (if disabled)
 
 ## Before Yielding Control
 

--- a/docs/guide/stage-transitions.md
+++ b/docs/guide/stage-transitions.md
@@ -173,7 +173,7 @@ The agent appends a one-liner to the `## Phase Candidates` section in `Implement
 When all planned phases complete, you'll be prompted to decide on each candidate:
 
 - **Promote** — Elaborate into a full phase with code research and planning
-- **Skip** — Mark as skipped and proceed to Final PR
+- **Skip** — Mark as skipped and move on
 - **Defer** — Mark as deferred for future work outside this workflow
 
 ## Checking Workflow Status

--- a/skills/paw-transition/SKILL.md
+++ b/skills/paw-transition/SKILL.md
@@ -53,14 +53,14 @@ Use the Mandatory Transitions table:
 
 ### Step 2.5: Candidate Promotion Check
 
-When next activity would be `paw-pr` (all planned phases complete), check for phase candidates:
+When all planned phases are complete (next activity would be `paw-final-review` or `paw-pr`), check for phase candidates:
 
 1. Read ImplementationPlan.md `## Phase Candidates` section
 2. Count **unresolved** candidates: `- [ ]` items WITHOUT terminal tags (`[skipped]`, `[deferred]`, `[not feasible]`)
 3. If unresolved candidates exist: set `promotion_pending = true` and extract candidate descriptions
 4. Otherwise: set `promotion_pending = false`
 
-If `promotion_pending = true`, return candidates in structured output. PAW orchestrator handles user interaction.
+If `promotion_pending = true`, return candidates in structured output. PAW orchestrator handles user interaction. Promoted candidates go through the standard flow (implement → impl-review) before final review runs, ensuring final review covers the complete implementation.
 
 ### Step 3: Check Stage Boundary and Milestone Pause
 
@@ -157,7 +157,7 @@ TRANSITION RESULT:
 - preflight: [passed | blocked: <reason>]
 - work_id: [current work ID]
 - inline_instruction: [for new_session only: resume hint]
-- promotion_pending: [true | false] (only when next would be paw-pr)
+- promotion_pending: [true | false] (only when all planned phases complete)
 - candidates: [list of unresolved candidate descriptions] (only if promotion_pending)
 ```
 


### PR DESCRIPTION
Phase candidate promotion was triggered only when next activity would be `paw-pr`, meaning final review ran on incomplete implementation when candidates existed. Promoted candidates produce new implementation phases that should be included in the final review scope.

**Before:** `all phases → final review (incomplete) → candidate promotion → paw-pr`
**After:** `all phases → candidate promotion → final review (complete) → paw-pr`

**Changes:**
- `skills/paw-transition/SKILL.md` — Step 2.5 trigger expanded from "next would be paw-pr" to "next would be paw-final-review or paw-pr" (all planned phases complete)
- `agents/PAW.agent.md` — Candidate Promotion Flow: after resolution, proceed to paw-final-review (if enabled) or paw-pr (if disabled)
- `docs/guide/stage-transitions.md` — Remove misleading "proceed to Final PR" from skip description

Fixes #244