### PR TITLE
fix: use checkbox format for Phase Candidates in paw-planning template

### DIFF
--- a/skills/paw-planning/SKILL.md
+++ b/skills/paw-planning/SKILL.md
@@ -96,8 +96,8 @@ Save to: `.paw/work/<work-id>/ImplementationPlan.md`
 - [ ] **Phase N: Documentation** - [If warranted]
 
 ## Phase Candidates
-<!-- Lightweight capture of potential phases identified during implementation.
-     Add one-liner descriptions here; elaborate into full phases later via promotion. -->
+<!-- Use checkbox format for each candidate so transition checks can detect unresolved items.
+     Example: - [ ] Moderator mode support -->
 
 ---
 


### PR DESCRIPTION
## Summary

The Phase Candidates template in `paw-planning/SKILL.md` used plain bullet format (`- Description`) instead of checkbox format (`- [ ] Description`). This caused `paw-transition` Step 2.5 to miss unresolved candidates, since it looks for `- [ ]` items.

## Changes

Updated the Phase Candidates template comment to use checkbox format with an example, so the agent produces `- [ ] Description` items that transition can detect.

Fixes #253