### PR TITLE
fix: default session_policy to continuous in CLI for paw-init

### DIFF
--- a/skills/paw-init/SKILL.md
+++ b/skills/paw-init/SKILL.md
@@ -28,7 +28,12 @@ Bootstrap skill that initializes the PAW workflow directory structure. This runs
 | `workflow_mode` | No | `full` | `full`, `minimal`, `custom` |
 | `review_strategy` | No | `prs` (`local` if minimal) | `prs`, `local` |
 | `review_policy` | No | `milestones` | `every-stage`, `milestones`, `planning-only`, `final-pr-only` |
+{{#vscode}}
 | `session_policy` | No | `per-stage` | `per-stage`, `continuous` |
+{{/vscode}}
+{{#cli}}
+| `session_policy` | No | `continuous` | `continuous` |
+{{/cli}}
 | `artifact_lifecycle` | No | `commit-and-clean` | `commit-and-clean`, `commit-and-persist`, `never-commit` |
 | `issue_url` | No | none | URL |
 | `custom_instructions` | Conditional | — | text (required if `workflow_mode` is `custom`) |


### PR DESCRIPTION
## Summary

`paw-init/SKILL.md` unconditionally defaulted `session_policy` to `per-stage`, but CLI operates in single-session mode where `per-stage` is not available. 

## Changes

Added `{{#cli}}`/`{{#vscode}}` conditionals around the `session_policy` parameter row so:
- **CLI**: defaults to `continuous` (only valid value)
- **VS Code**: defaults to `per-stage` (current behavior preserved)

This matches the pattern already used in `PAW.agent.md` (lines 79-96).

Fixes #250