### PR TITLE
fix: explicitly fetch both PR comment types in paw-review-response

### DIFF
--- a/skills/paw-review-response/SKILL.md
+++ b/skills/paw-review-response/SKILL.md
@@ -9,7 +9,7 @@ description: Shared PR review comment response mechanics for PAW activity skills
 
 ### 1. Read All Unresolved Comments
 
-- Use GitHub MCP tools to fetch PR comments and conversation threads
+- Fetch both top-level PR comments (`get_comments`) and inline review threads (`get_review_comments`)
 - Identify which comments still require work:
   - Check for follow-up commits addressing the comment
   - Check for reviewer replies indicating resolution


### PR DESCRIPTION
## Summary

The comment fetching instruction in `paw-review-response/SKILL.md` was vague:

> "Use GitHub MCP tools to fetch PR comments and conversation threads"

This caused agents to only fetch inline review comments (`get_review_comments`) and miss top-level PR discussion threads (`get_comments`).

## Changes

Updated the instruction to explicitly reference both API methods:
- `get_comments` — top-level PR discussion threads
- `get_review_comments` — inline code review threads

Fixes #106