### PR TITLE
Add context-based filtering

### DIFF
--- a/.paw/work/sot-context-filtering/CodeResearch.md
+++ b/.paw/work/sot-context-filtering/CodeResearch.md
@@ -1,0 +1,204 @@
+---
+date: 2026-03-01T11:05:00Z
+git_commit: 40105ef4ad48d3f93ea7fec5592127917d76bd69
+branch: feature/sot-context-filtering
+repository: erdemtuna/phased-agent-workflow
+topic: "SoT context-based specialist filtering"
+tags: [research, codebase, paw-sot, specialists, frontmatter]
+status: complete
+last_updated: 2026-03-01
+---
+
+# Research: SoT Context-Based Specialist Filtering
+
+## Research Question
+
+How does the paw-sot skill currently discover specialists, parse frontmatter, and where should context filtering be integrated?
+
+## Summary
+
+The paw-sot skill uses a 4-level precedence system for specialist discovery (workflow → project → user → built-in). Specialists are markdown files with YAML frontmatter. An existing `extractFrontmatterField()` utility supports case-insensitive field extraction. The filtering should occur after discovery and before adaptive selection. All 9 built-in specialists currently have no `context` field in frontmatter—they will need `context: implementation` added.
+
+## Documentation System
+
+- **Framework**: mkdocs (Material theme)
+- **Docs Directory**: `docs/`
+- **Navigation Config**: `mkdocs.yml:1`
+- **Style Conventions**: Technical reference style, code blocks with copy button
+- **Build Command**: `mkdocs build` (or `mkdocs serve` for local dev)
+- **Standard Files**: `README.md` (root), `CHANGELOG.md` (root), `docs/index.md`
+
+## Verification Commands
+
+- **Test Command**: `npm test`
+- **Lint Command**: `npm run lint`
+- **Build Command**: Not explicitly defined (VS Code extension, uses `vsce package`)
+- **Type Check**: Implicit via `eslint` with TypeScript support
+
+## Detailed Findings
+
+### Review Context Input Contract
+
+The review context contract is defined in SKILL.md lines 25-36. Current fields:
+
+| Field | Required | Values |
+|-------|----------|--------|
+| `type` | yes | `diff` \| `artifacts` \| `freeform` |
+| `coordinates` | yes | diff range, artifact paths, or content description |
+| `output_dir` | yes | directory path |
+| `specialists` | no | `all` (default) \| comma-separated names \| `adaptive:<N>` |
+| `interaction_mode` | yes | `parallel` \| `debate` |
+| `interactive` | yes | `true` \| `false` \| `smart` |
+| `specialist_models` | no | `none` \| model pool \| pinned pairs \| mixed |
+| `framing` | no | free text |
+| `perspectives` | no | `none` \| `auto` (default) \| comma-separated names |
+| `perspective_cap` | no | positive integer (default `2`) |
+
+The `context` field will be added as a new optional field.
+
+Location: `skills/paw-sot/SKILL.md:25-36`
+
+### Specialist Discovery Flow
+
+Discovery happens at 4 precedence levels (`SKILL.md:52-66`):
+
+1. **Workflow**: Parse `specialists` from review context
+2. **Project**: Scan `.paw/personas/<name>.md` files
+3. **User**: Scan `~/.paw/personas/<name>.md` files
+4. **Built-in**: Scan `references/specialists/<name>.md` files (excluding `_shared-rules.md`)
+
+Resolution rules:
+- `specialists: all` → include all discovered from all levels
+- Fixed list → resolve each name, most-specific-wins
+- `adaptive:<N>` → discover all, then select N most relevant
+
+Context filtering should occur **after discovery** (all specialists loaded with their frontmatter parsed) and **before adaptive selection** (filtered pool becomes input to adaptive).
+
+Location: `skills/paw-sot/SKILL.md:52-66`
+
+### Adaptive Selection
+
+Adaptive selection (`SKILL.md:68-85`) analyzes the review target to select N most relevant specialists. Key behaviors:
+
+- If N ≥ available specialists → include all
+- Trivial changes → report condition to caller
+- Zero relevant specialists (interactive) → prompt user
+- Zero relevant specialists (non-interactive) → report to caller
+
+The context filtering zero-match handling should follow similar patterns.
+
+Location: `skills/paw-sot/SKILL.md:68-85`
+
+### Frontmatter Extraction Utility
+
+The `extractFrontmatterField()` function in `src/utils/frontmatter.ts:19-52` provides:
+
+- Case-insensitive field name matching (`fieldName.toLowerCase()`)
+- Support for quoted and unquoted values
+- Colons within values handled correctly
+- Returns empty string if field not found or no frontmatter
+
+This utility is already used for `shared_rules_included` and `model` fields. It will work directly for extracting `context` field.
+
+Location: `src/utils/frontmatter.ts:19-52`
+
+### Current Frontmatter Usage in SKILL.md
+
+Two frontmatter fields are currently documented:
+
+1. **`shared_rules_included`** (`SKILL.md:126`): If `true`, skip shared rules injection
+2. **`model`** (`SKILL.md:149`): Pin specialist to a specific model
+
+The `context` field will follow the same pattern.
+
+### Built-in Specialist Files
+
+9 specialist files exist at `skills/paw-sot/references/specialists/`:
+
+1. `security.md`
+2. `architecture.md`
+3. `performance.md`
+4. `testing.md`
+5. `correctness.md`
+6. `edge-cases.md`
+7. `maintainability.md`
+8. `release-manager.md`
+9. `assumptions.md`
+
+Plus `_shared-rules.md` (loaded once, not a specialist).
+
+**Current frontmatter**: All specialist files have empty frontmatter (`---\n---` pattern, or no frontmatter at all). They start directly with `# [Specialist Name]`.
+
+Each specialist file contains:
+- Identity & Narrative Backstory
+- Cognitive Strategy
+- Domain Boundary / Behavioral Rules
+
+### Context-Adaptive Preambles
+
+Type-dependent preambles are injected during prompt composition (`SKILL.md:38-49`):
+
+- `type: diff` → implementation review framing
+- `type: artifacts` → design/planning review framing
+- `type: freeform` → caller-provided framing or neutral default
+
+These preambles are unaffected by context filtering—they serve a different purpose (prompt framing vs. specialist selection).
+
+### Interactive Patterns
+
+The skill has established patterns for interactive user prompts (`SKILL.md:82-83`):
+
+- **Interactive mode** (`interactive: true`): Present options to user
+- **Non-interactive mode** (`interactive: false`): Report to caller
+- **Smart mode** (`interactive: smart`): Escalate on significant conditions
+
+Zero-match context filtering should follow these same patterns.
+
+## Code References
+
+- `skills/paw-sot/SKILL.md:25-36` - Review context input contract
+- `skills/paw-sot/SKILL.md:52-66` - Specialist discovery
+- `skills/paw-sot/SKILL.md:68-85` - Adaptive selection
+- `skills/paw-sot/SKILL.md:126` - `shared_rules_included` frontmatter usage
+- `skills/paw-sot/SKILL.md:149` - `model` frontmatter usage
+- `src/utils/frontmatter.ts:19-52` - `extractFrontmatterField()` utility
+- `skills/paw-sot/references/specialists/*.md` - 9 built-in specialist files
+
+## Architecture Documentation
+
+### Flow Diagram
+
+```
+Review Context Input
+        │
+        ▼
+┌───────────────────┐
+│ Specialist        │  (4-level precedence)
+│ Discovery         │
+└─────────┬─────────┘
+          │
+          ▼
+┌───────────────────┐
+│ Context Filtering │  ◄── NEW: Extract context from frontmatter, match against caller
+└─────────┬─────────┘
+          │
+          ▼
+┌───────────────────┐
+│ Adaptive Selection│  (if specialists: adaptive:N)
+└─────────┬─────────┘
+          │
+          ▼
+     Prompt Composition → Execution → Synthesis
+```
+
+### Integration Points
+
+1. **Review Context Contract** - Add `context` field to table
+2. **Specialist Discovery section** - Add context extraction step
+3. **New "Context Filtering" section** - Document filtering behavior after discovery
+4. **Adaptive Selection section** - Clarify filtering happens first
+5. **Built-in specialist files** - Add `context: implementation` frontmatter
+
+## Open Questions
+
+None—all questions resolved during work shaping.

--- a/.paw/work/sot-context-filtering/Docs.md
+++ b/.paw/work/sot-context-filtering/Docs.md
@@ -1,0 +1,103 @@
+# Implementation Documentation: SoT Context-Based Specialist Filtering
+
+## Summary
+
+Added a `context` field to paw-sot specialist frontmatter and review context input contract, enabling domain-based specialist filtering while keeping the engine domain-agnostic.
+
+## Changes Made
+
+### paw-sot SKILL.md
+
+**Review Context Input Contract** (line ~31): Added `context` field:
+
+| Field | Required | Values | Description |
+|-------|----------|--------|-------------|
+| `context` | no | string | Domain filter for specialists (case-insensitive match) |
+
+**New "Context Filtering" section** (after Specialist Discovery): Documents:
+- Specialist context declaration via frontmatter
+- Case-insensitive matching behavior
+- Default behaviors for missing context
+- Zero-match handling (interactive prompt vs non-interactive fallback)
+- Execution order (filtering happens before adaptive selection)
+
+### Built-in Specialists
+
+Added `context: implementation` frontmatter to all 9 built-in specialists:
+- `security.md`
+- `architecture.md`
+- `performance.md`
+- `testing.md`
+- `correctness.md`
+- `edge-cases.md`
+- `maintainability.md`
+- `release-manager.md`
+- `assumptions.md`
+
+### Documentation
+
+Updated `docs/guide/society-of-thought-review.md`:
+- Added `context` field to specialist scaffold example
+- Added "Context Filtering" subsection under "Custom Specialists"
+
+## Usage
+
+### Caller Perspective
+
+To filter specialists by domain, include `context` in the review context:
+
+```yaml
+type: freeform
+context: business
+coordinates: /path/to/business-plan.md
+output_dir: .paw/work/my-work/reviews
+interaction_mode: parallel
+interactive: true
+```
+
+Only specialists with `context: business` in their frontmatter will participate.
+
+### Specialist Author Perspective
+
+To declare a specialist's domain context:
+
+```yaml
+---
+context: compliance
+---
+
+# Compliance Specialist
+
+## Identity & Narrative Backstory
+...
+```
+
+## Default Behaviors
+
+| Scenario | Default |
+|----------|---------|
+| Specialist without `context` field | `implementation` |
+| Caller without `context` + `diff` type | `implementation` |
+| Caller without `context` + `artifacts` type | `implementation` |
+| Caller without `context` + `freeform` type | No filtering |
+
+## Zero-Match Handling
+
+| Mode | Behavior |
+|------|----------|
+| `interactive: true` | Warn and prompt user for decision |
+| `interactive: false` | Warn and proceed with all specialists |
+| `interactive: smart` | Warn and prompt user |
+
+## Verification
+
+- Agent lint: `./scripts/lint-prompting.sh skills/paw-sot/SKILL.md` ✓
+- Skills lint: `npm run lint:skills` ✓
+- Docs build: `mkdocs build --strict` ✓
+
+## References
+
+- Issue: https://github.com/lossyrob/phased-agent-workflow/issues/262
+- Spec: `.paw/work/sot-context-filtering/Spec.md`
+- CodeResearch: `.paw/work/sot-context-filtering/CodeResearch.md`
+- ImplementationPlan: `.paw/work/sot-context-filtering/ImplementationPlan.md`

--- a/.paw/work/sot-context-filtering/ImplementationPlan.md
+++ b/.paw/work/sot-context-filtering/ImplementationPlan.md
@@ -1,0 +1,168 @@
+# SoT Context-Based Specialist Filtering Implementation Plan
+
+## Overview
+
+Adding a `context` field to SoT specialist frontmatter and review context input contract, enabling domain-based specialist filtering while keeping the engine domain-agnostic through pure string matching.
+
+## Current State Analysis
+
+- SoT discovers specialists from 4 levels (workflow → project → user → built-in)
+- Frontmatter extraction exists via `extractFrontmatterField()` (case-insensitive)
+- 9 built-in specialists have no `context` field currently
+- Adaptive selection already filters post-discovery—context filtering follows same pattern
+- Interactive/non-interactive patterns established for edge cases
+
+## Desired End State
+
+- Specialists can declare `context: <string>` in frontmatter
+- Callers can filter by context via `context: <string>` in review context
+- Case-insensitive string matching (no semantic interpretation)
+- Backward compatible: missing context defaults to `implementation`
+- Zero-match handling follows established interactive patterns
+
+## What We're NOT Doing
+
+- Multiple contexts per specialist (arrays)—deferred for future enhancement
+- Context validation or registry—SoT remains domain-agnostic
+- New non-implementation specialists—external workflows provide their own
+- Context-aware prompt framing—context is purely filtering
+- Changes to perspective system or shared rules
+
+## Phase Status
+
+- [ ] **Phase 1: SKILL.md Updates** - Add context field to contract and document filtering behavior
+- [ ] **Phase 2: Built-in Specialist Updates** - Add `context: implementation` to all 9 specialists
+- [ ] **Phase 3: Documentation** - Create Docs.md and update project documentation
+
+## Phase Candidates
+
+<!-- None currently - all requirements fit within planned phases -->
+
+---
+
+## Phase 1: SKILL.md Updates
+
+Add context filtering mechanism to the paw-sot skill documentation.
+
+### Changes Required
+
+- **`skills/paw-sot/SKILL.md`**:
+  - Add `context` field to Review Context Input Contract table (line ~36)
+  - Add new "Context Filtering" section after Specialist Discovery section (after line 66)
+  - Update Adaptive Selection section to clarify context filtering happens first
+  - Document zero-match handling following established interactive patterns
+
+### Detailed Changes
+
+**Review Context Input Contract** (add row to table):
+| Field | Required | Values | Description |
+|-------|----------|--------|-------------|
+| `context` | no | string | Domain filter for specialists (case-insensitive match) |
+
+**New "Context Filtering" Section** (insert after Specialist Discovery):
+- Context is optional string field in review context
+- Specialists declare context via `context:` frontmatter field
+- Matching is case-insensitive
+- Default behaviors:
+  - Specialists without `context` → default to `implementation`
+  - Callers without `context` + `diff`/`artifacts` type → default to `implementation`
+  - Callers without `context` + `freeform` type → no filtering
+- Zero-match handling:
+  - Interactive mode → prompt user for decision
+  - Non-interactive mode → warn and include all specialists
+  - Smart mode → prompt user (escalate on zero-match)
+
+**Adaptive Selection Update**:
+- Add note: "Context filtering (if specified) occurs before adaptive selection—the adaptive algorithm selects from the already-filtered pool."
+
+### Success Criteria
+
+#### Automated Verification:
+- [ ] Agent lint passes: `./scripts/lint-prompting.sh skills/paw-sot/SKILL.md`
+
+#### Manual Verification:
+- [ ] Context field documented in input contract table
+- [ ] Context Filtering section describes all default behaviors
+- [ ] Zero-match handling follows established patterns
+- [ ] Adaptive Selection references context filtering precedence
+
+---
+
+## Phase 2: Built-in Specialist Updates
+
+Add explicit `context: implementation` frontmatter to all built-in specialists.
+
+### Changes Required
+
+- **`skills/paw-sot/references/specialists/security.md`**: Add frontmatter
+- **`skills/paw-sot/references/specialists/architecture.md`**: Add frontmatter
+- **`skills/paw-sot/references/specialists/performance.md`**: Add frontmatter
+- **`skills/paw-sot/references/specialists/testing.md`**: Add frontmatter
+- **`skills/paw-sot/references/specialists/correctness.md`**: Add frontmatter
+- **`skills/paw-sot/references/specialists/edge-cases.md`**: Add frontmatter
+- **`skills/paw-sot/references/specialists/maintainability.md`**: Add frontmatter
+- **`skills/paw-sot/references/specialists/release-manager.md`**: Add frontmatter
+- **`skills/paw-sot/references/specialists/assumptions.md`**: Add frontmatter
+
+### Frontmatter Pattern
+
+Each specialist file should start with:
+```yaml
+---
+context: implementation
+---
+```
+
+Files currently have no frontmatter (start with `# [Name]`) or empty frontmatter (`---\n---`).
+
+### Success Criteria
+
+#### Automated Verification:
+- [ ] Agent lint passes for all specialists: `npm run lint:skills`
+
+#### Manual Verification:
+- [ ] All 9 specialist files have `context: implementation` in frontmatter
+- [ ] No other content changes to specialist files
+- [ ] `_shared-rules.md` unchanged (not a specialist)
+
+---
+
+## Phase 3: Documentation
+
+Create technical reference and update project documentation.
+
+### Changes Required
+
+- **`.paw/work/sot-context-filtering/Docs.md`**: Technical reference (load `paw-docs-guidance`)
+- **`docs/reference/` or appropriate location**: Document context filtering for specialist authors
+
+### Documentation Content
+
+**Docs.md** should cover:
+- Feature overview
+- Usage examples (caller perspective)
+- Specialist author guide (frontmatter format)
+- Default behaviors table
+- Verification approach
+
+**Project docs** should include:
+- Specialist authoring guide with context field documentation
+- Example of creating domain-specific specialists
+
+### Success Criteria
+
+#### Automated Verification:
+- [ ] Docs build: `mkdocs build --strict`
+
+#### Manual Verification:
+- [ ] Docs.md captures implementation details
+- [ ] Specialist author documentation is discoverable
+- [ ] Examples are clear and actionable
+
+---
+
+## References
+
+- Issue: https://github.com/lossyrob/phased-agent-workflow/issues/262
+- Spec: `.paw/work/sot-context-filtering/Spec.md`
+- Research: `.paw/work/sot-context-filtering/CodeResearch.md`

--- a/.paw/work/sot-context-filtering/ImplementationPlan.md
+++ b/.paw/work/sot-context-filtering/ImplementationPlan.md
@@ -30,9 +30,9 @@ Adding a `context` field to SoT specialist frontmatter and review context input 
 
 ## Phase Status
 
-- [ ] **Phase 1: SKILL.md Updates** - Add context field to contract and document filtering behavior
-- [ ] **Phase 2: Built-in Specialist Updates** - Add `context: implementation` to all 9 specialists
-- [ ] **Phase 3: Documentation** - Create Docs.md and update project documentation
+- [x] **Phase 1: SKILL.md Updates** - Add context field to contract and document filtering behavior
+- [x] **Phase 2: Built-in Specialist Updates** - Add `context: implementation` to all 9 specialists
+- [x] **Phase 3: Documentation** - Create Docs.md and update project documentation
 
 ## Phase Candidates
 

--- a/.paw/work/sot-context-filtering/Spec.md
+++ b/.paw/work/sot-context-filtering/Spec.md
@@ -1,0 +1,134 @@
+# Feature Specification: Context-Based Specialist Filtering
+
+**Branch**: feature/sot-context-filtering  |  **Created**: 2026-03-01  |  **Status**: Draft
+**Input Brief**: Add domain filtering to SoT so specialists can declare their context and callers can filter to relevant specialists
+
+## Overview
+
+The Society of Thought (SoT) engine orchestrates multi-perspective code reviews by invoking specialist personas (security, performance, testing, etc.). Currently, all discovered specialists participate in every review regardless of whether they're relevant to the content being reviewed. This works well for implementation-focused code reviews but creates friction when reviewing non-code content like business plans, documentation, or domain-specific artifacts where implementation specialists add noise rather than value.
+
+External workflow authors who create custom specialists for their domains (compliance, business analysis, legal review) have no way to ensure only their relevant specialists participate when their workflows invoke SoT. The current workaround—explicitly listing specialist names in the `specialists` field—is fragile and doesn't scale when specialists are contributed from multiple sources.
+
+This feature introduces a generic context-filtering mechanism where specialists declare their domain via a `context` field in YAML frontmatter, and callers specify which context they want via a new `context` field in the review context contract. SoT matches these strings without interpreting what they mean, keeping the engine domain-agnostic while enabling precise specialist scoping.
+
+## Objectives
+
+- Enable callers to filter specialists by domain without knowing individual specialist names
+- Allow specialist authors to declare relevance domains in a standard, discoverable way
+- Maintain full backward compatibility—existing specialists and callers work unchanged
+- Keep SoT domain-agnostic—no hardcoded knowledge of what contexts mean
+- Support external workflows bringing their own domain-specific specialists
+
+## User Scenarios & Testing
+
+### User Story P1 – External Workflow Filtering
+
+**Narrative**: A workflow author creates custom specialists for business document reviews (market-analyst, financial-reviewer). When their workflow invokes SoT with `context: business`, only their business specialists participate—implementation specialists are automatically excluded.
+
+**Independent Test**: Invoke SoT with `context: business` when both `context: business` and `context: implementation` specialists exist; verify only business specialists participate.
+
+**Acceptance Scenarios**:
+1. Given specialists with `context: business` and `context: implementation` exist, When caller passes `context: business`, Then only business-context specialists are selected
+2. Given a specialist has `context: business` in frontmatter, When SoT loads specialists, Then the context value is extracted and available for filtering
+3. Given caller passes `context: compliance`, When no specialists have `context: compliance`, Then a warning is emitted
+
+### User Story P2 – Backward Compatible Default
+
+**Narrative**: An existing PAW user runs SoT code reviews without specifying any context. Their reviews continue to work exactly as before, with all implementation specialists participating.
+
+**Independent Test**: Invoke SoT without `context` field on a diff review; verify all implementation specialists participate.
+
+**Acceptance Scenarios**:
+1. Given a specialist file has no `context` field, When SoT loads it, Then the specialist defaults to `context: implementation`
+2. Given caller invokes SoT with type `diff` and no `context` field, When SoT determines filtering, Then it defaults to `context: implementation`
+3. Given caller invokes SoT with type `freeform` and no `context` field, When SoT determines filtering, Then no context filtering is applied
+
+### User Story P3 – Zero-Match Recovery
+
+**Narrative**: A user accidentally passes `context: busines` (typo). In interactive mode, SoT warns them and asks how to proceed. In non-interactive mode, SoT warns and falls back to all specialists rather than failing silently.
+
+**Independent Test**: Invoke SoT with a context that matches no specialists in both interactive and non-interactive modes; verify appropriate handling.
+
+**Acceptance Scenarios**:
+1. Given `interactive: true` and no specialists match the requested context, When filtering completes, Then user is prompted to decide how to proceed
+2. Given `interactive: false` and no specialists match the requested context, When filtering completes, Then a warning is emitted and all specialists are included as fallback
+3. Given `interactive: smart` and no specialists match the requested context, When filtering completes, Then user is prompted (smart escalates on zero-match)
+
+### Edge Cases
+
+- Context matching is case-insensitive (`Business` matches `business`)
+- Empty string context treated as no context specified (use defaults)
+- Whitespace-only context treated as no context specified
+- Context filtering applies before adaptive selection (`specialists: adaptive:3` selects from filtered pool)
+
+## Requirements
+
+### Functional Requirements
+
+- FR-001: Specialists MAY declare a `context` field in YAML frontmatter with a single string value (Stories: P1, P2)
+- FR-002: Review context input contract accepts an optional `context` field with a string value (Stories: P1)
+- FR-003: When caller provides `context`, only specialists with matching context (case-insensitive) are included (Stories: P1)
+- FR-004: Specialists without explicit `context` field default to `implementation` (Stories: P2)
+- FR-005: Callers without explicit `context` field default to `implementation` for `diff` and `artifacts` types (Stories: P2)
+- FR-006: Callers without explicit `context` field have no filtering for `freeform` type (Stories: P2)
+- FR-007: Context filtering occurs after specialist discovery and before adaptive selection (Stories: P1)
+- FR-008: Zero matching specialists in interactive mode prompts user for decision (Stories: P3)
+- FR-009: Zero matching specialists in non-interactive mode emits warning and includes all specialists (Stories: P3)
+- FR-010: All built-in specialists have explicit `context: implementation` in frontmatter (Stories: P2)
+
+### Cross-Cutting / Non-Functional
+
+- Context matching must be case-insensitive to reduce user friction from typos
+- Warning messages for zero-match must be visible in output (not silent)
+- No new review types or context values hardcoded in SoT—purely string matching
+
+## Success Criteria
+
+- SC-001: Caller can filter to only business specialists by passing `context: business` (FR-003)
+- SC-002: Existing callers without `context` field see no change in behavior for diff reviews (FR-004, FR-005)
+- SC-003: Zero-match scenarios are handled gracefully without silent failures (FR-008, FR-009)
+- SC-004: Specialist authors can document context in frontmatter following existing patterns (FR-001)
+- SC-005: Context filtering integrates with adaptive selection—filtered pool is input to adaptive (FR-007)
+
+## Assumptions
+
+- Single context per specialist is sufficient for initial release; multi-context arrays deferred
+- Case-insensitive matching provides better UX than strict case-sensitivity
+- External workflow authors will create their own specialists rather than expecting PAW to ship non-implementation specialists
+- The existing `extractFrontmatterField` utility handles the `context` field extraction
+
+## Scope
+
+**In Scope**:
+- `context` field in specialist frontmatter
+- `context` field in review context input contract
+- Context filtering logic in specialist selection flow
+- Default behavior for missing context (specialists and callers)
+- Zero-match handling (interactive prompt, non-interactive fallback)
+- Adding `context: implementation` to all 9 built-in specialists
+- Documentation for specialist authors
+
+**Out of Scope**:
+- Multiple contexts per specialist (arrays)
+- Context validation or registry of known contexts
+- New built-in specialists for non-implementation domains
+- Changes to perspective system
+- Changes to shared rules injection
+- Context-aware prompt framing (context is filtering only)
+
+## Dependencies
+
+- Existing frontmatter extraction utility (`extractFrontmatterField`)
+- Existing specialist discovery mechanism (4-level precedence)
+- Existing interactive prompt patterns
+
+## Risks & Mitigations
+
+- **Typo-induced zero matches**: Users may mistype context strings. Mitigation: Case-insensitive matching reduces this; clear warning messages help users identify the issue.
+- **Unexpected freeform behavior**: `freeform` type has no default filtering, which may surprise users expecting implementation specialists. Mitigation: Document this clearly in the review context contract.
+- **Silent fallback confusion**: Non-interactive fallback to all specialists might mask configuration errors. Mitigation: Warning must be prominent, not buried in logs.
+
+## References
+
+- Issue: https://github.com/lossyrob/phased-agent-workflow/issues/262
+- WorkShaping: .paw/work/sot-context-filtering/WorkShaping.md

--- a/.paw/work/sot-context-filtering/WorkShaping.md
+++ b/.paw/work/sot-context-filtering/WorkShaping.md
@@ -1,0 +1,144 @@
+# Work Shaping: Context-Based Specialist Filtering for paw-sot
+
+Issue: [lossyrob/phased-agent-workflow#262](https://github.com/lossyrob/phased-agent-workflow/issues/262)
+
+## Problem Statement
+
+The SoT (Society of Thought) engine currently loads all discovered specialists regardless of review domain. This works for implementation-focused code reviews, but doesn't support:
+
+- **External workflows** bringing domain-specific specialists (e.g., business analysis, compliance)
+- **Non-code reviews** where implementation specialists (security, performance, testing) are irrelevant
+
+Users can create custom specialists in `~/.paw/personas/` or `.paw/personas/`, but there's no way to scope which specialists participate based on the review domain.
+
+**Who benefits**: External contributors creating custom workflows with their own domain specialists, and PAW core when it needs domain-specific reviews.
+
+## Work Breakdown
+
+### Core Functionality
+
+1. **Specialist context declaration** - Add `context` field to specialist frontmatter
+2. **Review context filter** - Add `context` field to review context input contract
+3. **Context matching logic** - Pure string matching between caller context and specialist context
+4. **Default behavior** - Backward-compatible defaults for callers and specialists without explicit context
+
+### Supporting Features
+
+1. **Built-in specialist updates** - Add explicit `context: implementation` to all existing specialists
+2. **Zero-match handling** - Interactive prompt vs. non-interactive fallback
+3. **Documentation** - Document mechanism for specialist authors
+
+## Edge Cases
+
+| Scenario | Expected Handling |
+|----------|-------------------|
+| Specialist without `context` field | Default to `implementation` (backward compatible) |
+| Caller without `context` field + `diff`/`artifacts` type | Default to `implementation` |
+| Caller without `context` field + `freeform` type | No filtering (all specialists participate) |
+| Zero specialists match the context (interactive mode) | Warn and prompt user for decision |
+| Zero specialists match the context (non-interactive mode) | Warn and proceed with all specialists |
+| Context filter + adaptive selection | Filter by context first, then adaptive selects from filtered pool |
+
+## Rough Architecture
+
+```
+Review Context Input
+        │
+        ▼
+┌───────────────────┐
+│ Specialist        │  (4-level precedence: workflow → project → user → built-in)
+│ Discovery         │
+└─────────┬─────────┘
+          │
+          ▼
+┌───────────────────┐
+│ Context Filtering │  ◄── NEW: Match caller context against specialist context
+│ (if context set)  │
+└─────────┬─────────┘
+          │
+          ▼
+┌───────────────────┐
+│ Adaptive Selection│  (if specialists: adaptive:N)
+│ (from filtered    │
+│  pool)            │
+└─────────┬─────────┘
+          │
+          ▼
+     SoT Execution
+```
+
+### Data Flow
+
+1. Caller provides review context with optional `context: <string>` field
+2. Discovery phase loads all specialists from 4-level hierarchy
+3. **New filtering step**: Extract `context` from each specialist's frontmatter; retain only specialists where context matches (or both are `implementation` by default)
+4. Filtered pool feeds into existing adaptive selection (if used) or direct execution
+
+### Component Interactions
+
+- **SKILL.md § Review Context Input Contract**: Add `context` field documentation
+- **SKILL.md § Execution**: Add context filtering step after discovery, before adaptive selection
+- **Specialist files**: Parse frontmatter for `context` field
+- **_shared-rules.md**: No changes expected (context is purely filtering, not prompt framing)
+
+## Critical Analysis
+
+### Value Assessment
+
+**High value**: This is a clean extension that enables new use cases without modifying core SoT logic. Domain-agnostic design means PAW doesn't need to know about every possible review domain.
+
+### Build vs. Modify Tradeoffs
+
+**Modify existing**: This extends the existing specialist loading flow with a filtering step. No new components needed.
+
+### Simplicity Wins
+
+- Single context per specialist (not arrays) — can extend later if needed
+- Pure string matching — no semantic interpretation
+- Defaults preserve existing behavior — zero breaking changes
+
+## Codebase Fit
+
+### Similar Features
+
+- Specialist discovery already has precedence logic (workflow → project → user → built-in)
+- Frontmatter parsing exists for `model:` and `shared_rules_included:` fields
+- Adaptive selection already filters specialists by relevance scoring
+
+### Reuse Opportunities
+
+- Existing frontmatter extraction utilities
+- Existing specialist loading infrastructure
+- Existing interactive prompt patterns for edge cases
+
+## Risk Assessment
+
+### Potential Negative Impacts
+
+- **Zero matches silently proceeding**: If non-interactive mode falls back to all specialists, the caller might not realize filtering failed. Mitigation: Always emit a visible warning.
+- **Context typos**: A caller passing `implmentation` (typo) won't match `implementation` specialists. Mitigation: Documentation should emphasize exact string matching.
+
+### Gotchas
+
+- Context is **case-sensitive** string matching — document this clearly
+- The `freeform` type has no default filtering, which might surprise callers expecting implementation specialists
+
+## Open Questions
+
+1. **Case sensitivity**: Should context matching be case-insensitive for usability? (Current decision: case-sensitive for simplicity, but could revisit)
+2. **Warning visibility**: How prominently should the zero-match warning be displayed in non-interactive mode?
+
+## Session Notes
+
+### Key Decisions
+
+- **Single context per specialist** chosen over multi-context for initial simplicity; can extend later
+- **Defaults follow issue proposal**: specialists default to `implementation`, callers default based on review type
+- **Filtering before adaptive selection** — filter first, then let adaptive select from filtered pool
+- **Add explicit context to built-ins** even though they default to `implementation`, for clarity
+
+### Rejected Alternatives
+
+- **Multi-context arrays**: Deferred for simplicity. Authors can create specialist variants if needed.
+- **Context registry/validation**: Rejected to keep SoT domain-agnostic. Any string is valid.
+- **Integrated adaptive scoring**: Rejected in favor of separate filter step for clarity.

--- a/.paw/work/sot-context-filtering/WorkflowContext.md
+++ b/.paw/work/sot-context-filtering/WorkflowContext.md
@@ -1,0 +1,34 @@
+# WorkflowContext
+
+Work Title: SoT Context Filtering
+Work ID: sot-context-filtering
+Base Branch: main
+Target Branch: feature/sot-context-filtering
+Workflow Mode: full
+Review Strategy: local
+Review Policy: final-pr-only
+Session Policy: continuous
+Final Agent Review: enabled
+Final Review Mode: multi-model
+Final Review Interactive: smart
+Final Review Models: gpt-5.2, gemini-3-pro-preview, claude-opus-4.6
+Final Review Specialists: all
+Final Review Interaction Mode: parallel
+Final Review Specialist Models: none
+Plan Generation Mode: single-model
+Plan Generation Models: gpt-5.2, gemini-3-pro-preview, claude-opus-4.6
+Planning Docs Review: enabled
+Planning Review Mode: multi-model
+Planning Review Interactive: smart
+Planning Review Models: gpt-5.2, gemini-3-pro-preview, claude-opus-4.6
+Custom Workflow Instructions: none
+Initial Prompt: none
+Issue URL: https://github.com/lossyrob/phased-agent-workflow/issues/262
+Remote: origin
+Artifact Lifecycle: commit-and-clean
+Artifact Paths: auto-derived
+Additional Inputs: none
+
+## Workflow State
+
+Current Stage: spec

--- a/.paw/work/sot-context-filtering/WorkflowContext.md
+++ b/.paw/work/sot-context-filtering/WorkflowContext.md
@@ -31,4 +31,5 @@ Additional Inputs: none
 
 ## Workflow State
 
-Current Stage: spec
+Current Stage: implement
+Current Phase: 1

--- a/.paw/work/sot-context-filtering/WorkflowContext.md
+++ b/.paw/work/sot-context-filtering/WorkflowContext.md
@@ -31,5 +31,5 @@ Additional Inputs: none
 
 ## Workflow State
 
-Current Stage: implement
-Current Phase: 1
+Current Stage: complete
+PR: https://github.com/erdemtuna/phased-agent-workflow/pull/3

--- a/docs/guide/society-of-thought-review.md
+++ b/docs/guide/society-of-thought-review.md
@@ -186,6 +186,7 @@ A specialist file is a markdown document that defines a persona. The filename (w
 
 ```markdown
 ---
+context: implementation
 shared_rules_included: false
 ---
 
@@ -256,6 +257,28 @@ shared rules (Finding → Grounds → Warrant → Rebuttal Conditions
 - **Anti-sycophancy is structural, not stylistic.** The shared rules enforce that every specialist must produce substantive analysis. Don't override these in custom specialists.
 - **Use `shared_rules_included` frontmatter.** Set to `true` only if your custom specialist includes its own anti-sycophancy rules, confidence scoring, and Toulmin output format. When `false` (default), shared rules are automatically injected.
 - **Include example findings.** 2-3 examples in the Toulmin format (Grounds → Warrant → Rebuttal → Verification) anchor the specialist's behavior more effectively than additional instructions.
+
+### Context Filtering
+
+Specialists can declare a domain context in their frontmatter, allowing callers to filter to only relevant specialists for their review type. This enables domain-specific reviews where implementation specialists (security, performance, etc.) don't participate when reviewing non-code content like business plans or documentation.
+
+**Declaring context in a specialist:**
+
+```yaml
+---
+context: business
+---
+```
+
+**Filtering by context:** Callers specify `context: <domain>` in the review context. Only specialists with matching context (case-insensitive) participate.
+
+**Default behaviors:**
+
+- Specialists without a `context` field default to `implementation`
+- For `diff` and `artifacts` review types without explicit context, filtering defaults to `implementation`
+- For `freeform` review type without explicit context, no filtering occurs (all specialists participate)
+
+All 9 built-in specialists have `context: implementation`. To create specialists for other domains (compliance, business analysis, etc.), add the appropriate `context` field to your custom specialist's frontmatter.
 
 ## Custom Perspectives
 

--- a/docs/guide/society-of-thought-review.md
+++ b/docs/guide/society-of-thought-review.md
@@ -270,6 +270,8 @@ context: business
 ---
 ```
 
+Each specialist declares a single context value — comma-separated or array values are not supported.
+
 **Filtering by context:** Callers specify `context: <domain>` in the review context. Only specialists with matching context (case-insensitive) participate.
 
 **Default behaviors:**
@@ -286,6 +288,9 @@ context: business
 This means typos in context values are recoverable — you'll always get a clear warning rather than a silent failure.
 
 All 9 built-in specialists have `context: implementation`. To create specialists for other domains (compliance, business analysis, etc.), add the appropriate `context` field to your custom specialist's frontmatter.
+
+!!! tip
+    For `freeform` reviews of non-code content, always specify `context` to ensure only relevant specialists participate. Without an explicit `context`, all specialists are included regardless of domain.
 
 ## Custom Perspectives
 

--- a/docs/guide/society-of-thought-review.md
+++ b/docs/guide/society-of-thought-review.md
@@ -278,6 +278,13 @@ context: business
 - For `diff` and `artifacts` review types without explicit context, filtering defaults to `implementation`
 - For `freeform` review type without explicit context, no filtering occurs (all specialists participate)
 
+**Zero-match handling:** If no specialists match the requested context:
+
+- In **interactive** or **smart** mode, SoT warns you and asks how to proceed
+- In **non-interactive** mode, SoT warns and falls back to all specialists
+
+This means typos in context values are recoverable — you'll always get a clear warning rather than a silent failure.
+
 All 9 built-in specialists have `context: implementation`. To create specialists for other domains (compliance, business analysis, etc.), add the appropriate `context` field to your custom specialist's frontmatter.
 
 ## Custom Perspectives

--- a/skills/paw-sot/SKILL.md
+++ b/skills/paw-sot/SKILL.md
@@ -28,6 +28,7 @@ The calling skill provides a **review context** describing what to review and ho
 | `coordinates` | yes | diff range, artifact paths, or content description | What to point specialists at |
 | `output_dir` | yes | directory path | Where to write REVIEW-*.md files |
 | `specialists` | no | `all` (default) \| comma-separated names \| `adaptive:<N>` | Which specialists to invoke |
+| `context` | no | string | Domain filter for specialists (case-insensitive match) |
 | `interaction_mode` | yes | `parallel` \| `debate` | How specialists interact |
 | `interactive` | yes | `true` \| `false` \| `smart` | Whether to pause for user decisions on trade-offs |
 | `specialist_models` | no | `none` \| model pool \| pinned pairs \| mixed | Model assignment for specialists |
@@ -64,6 +65,35 @@ Resolution rules:
 - Same filename at project level overrides user level overrides built-in
 - Skip malformed or empty specialist files with a warning; continue with remaining roster
 - If zero specialists found after discovery, fall back to built-in defaults with a warning
+
+## Context Filtering
+
+When the review context includes a `context` field, filter discovered specialists to only those matching the specified domain. This enables domain-specific reviews where only relevant specialists participate.
+
+**Specialist context declaration**: Specialists declare their domain via a `context` field in YAML frontmatter:
+
+```yaml
+---
+context: implementation
+---
+```
+
+**Matching behavior**:
+- Case-insensitive string comparison (e.g., `Business` matches `business`)
+- Empty or whitespace-only context treated as not specified
+
+**Default behaviors**:
+- Specialists without explicit `context` field default to `implementation`
+- Callers without `context` field:
+  - `diff` and `artifacts` types → default to `implementation`
+  - `freeform` type → no filtering (all specialists participate)
+
+**Zero-match handling**: If context filtering results in zero matching specialists:
+- **Interactive mode** (`interactive: true`): Warn and prompt user — options: proceed with all specialists, specify different context, or abort
+- **Non-interactive mode** (`interactive: false`): Warn and proceed with all specialists as fallback
+- **Smart mode** (`interactive: smart`): Warn and prompt user (escalate on zero-match)
+
+**Execution order**: Context filtering occurs after specialist discovery and before adaptive selection. When both context filtering and adaptive selection are active, the adaptive algorithm selects from the already-filtered pool.
 
 ## Adaptive Selection
 

--- a/skills/paw-sot/SKILL.md
+++ b/skills/paw-sot/SKILL.md
@@ -28,7 +28,7 @@ The calling skill provides a **review context** describing what to review and ho
 | `coordinates` | yes | diff range, artifact paths, or content description | What to point specialists at |
 | `output_dir` | yes | directory path | Where to write REVIEW-*.md files |
 | `specialists` | no | `all` (default) \| comma-separated names \| `adaptive:<N>` | Which specialists to invoke |
-| `context` | no | string | Domain filter for specialists (case-insensitive match) |
+| `context` | no | string (type-dependent default — see Context Filtering) | Domain filter for specialists (case-insensitive match) |
 | `interaction_mode` | yes | `parallel` \| `debate` | How specialists interact |
 | `interactive` | yes | `true` \| `false` \| `smart` | Whether to pause for user decisions on trade-offs |
 | `specialist_models` | no | `none` \| model pool \| pinned pairs \| mixed | Model assignment for specialists |
@@ -68,6 +68,8 @@ Resolution rules:
 
 ## Context Filtering
 
+> The `context` field (domain filter) is distinct from the review context input structure.
+
 When the review context includes a `context` field, filter discovered specialists to only those matching the specified domain. This enables domain-specific reviews where only relevant specialists participate.
 
 **Specialist context declaration**: Specialists declare their domain via a `context` field in YAML frontmatter:
@@ -79,11 +81,11 @@ context: implementation
 ```
 
 **Matching behavior**:
+- Each specialist declares a single context value (comma-separated or array values are not supported)
 - Case-insensitive string comparison (e.g., `Business` matches `business`)
-- Empty or whitespace-only context treated as not specified
 
 **Default behaviors**:
-- Specialists without explicit `context` field default to `implementation`
+- Specialists without a `context` field, or with an empty/whitespace-only `context` value, default to `implementation`
 - Callers without `context` field:
   - `diff` and `artifacts` types → default to `implementation`
   - `freeform` type → no filtering (all specialists participate)
@@ -91,9 +93,9 @@ context: implementation
 **Zero-match handling**: If context filtering results in zero matching specialists:
 - **Interactive mode** (`interactive: true`): Warn and prompt user — options: proceed with all specialists, specify different context, or abort
 - **Non-interactive mode** (`interactive: false`): Warn and proceed with all specialists as fallback
-- **Smart mode** (`interactive: smart`): Warn and prompt user (escalate on zero-match)
+- **Smart mode** (`interactive: smart`): Warn and prompt user (escalate on zero-match — context misconfiguration is more likely a setup error than a soft signal, warranting user confirmation)
 
-**Execution order**: Context filtering occurs after specialist discovery and before adaptive selection. When both context filtering and adaptive selection are active, the adaptive algorithm selects from the already-filtered pool.
+**Execution order**: Context filtering occurs after specialist discovery and before adaptive selection. When both context filtering and adaptive selection are active, the adaptive algorithm selects from the already-filtered pool. When a fixed specialist list is provided, context filtering is skipped — explicit naming overrides domain filtering.
 
 ## Adaptive Selection
 

--- a/skills/paw-sot/SKILL.md
+++ b/skills/paw-sot/SKILL.md
@@ -97,7 +97,7 @@ context: implementation
 
 ## Adaptive Selection
 
-When `specialists` is `adaptive:<N>`, select the N most relevant specialists from the full discovered roster based on content analysis.
+When `specialists` is `adaptive:<N>`, select the N most relevant specialists from the discovered roster (after any context filtering) based on content analysis.
 
 **Selection process**:
 1. Analyze the review target to identify dominant change categories — file types, affected subsystems, nature of changes (new logic, refactoring, config, API surface, data handling, test coverage)
@@ -258,6 +258,7 @@ The Finding sections (Must-Fix, Should-Fix, Consider) are the actionable items p
 ## Review Summary
 - Mode: society-of-thought (parallel | debate)
 - Specialists: [list of participating specialists]
+- Context: [context value used for filtering, or "none"]
 - Perspectives: [list of perspectives applied, or "none"]
 - Perspective cap: [configured cap value]
 - Selection rationale: [if adaptive mode was used]

--- a/skills/paw-sot/references/specialists/architecture.md
+++ b/skills/paw-sot/references/specialists/architecture.md
@@ -1,3 +1,7 @@
+---
+context: implementation
+---
+
 # Architecture Specialist
 
 ## Identity & Narrative Backstory

--- a/skills/paw-sot/references/specialists/assumptions.md
+++ b/skills/paw-sot/references/specialists/assumptions.md
@@ -1,3 +1,7 @@
+---
+context: implementation
+---
+
 # Assumptions Specialist
 
 ## Identity & Narrative Backstory

--- a/skills/paw-sot/references/specialists/correctness.md
+++ b/skills/paw-sot/references/specialists/correctness.md
@@ -1,3 +1,7 @@
+---
+context: implementation
+---
+
 # Correctness Specialist
 
 ## Identity & Narrative Backstory

--- a/skills/paw-sot/references/specialists/edge-cases.md
+++ b/skills/paw-sot/references/specialists/edge-cases.md
@@ -1,3 +1,7 @@
+---
+context: implementation
+---
+
 # Edge Cases Specialist
 
 ## Identity & Narrative Backstory

--- a/skills/paw-sot/references/specialists/maintainability.md
+++ b/skills/paw-sot/references/specialists/maintainability.md
@@ -1,3 +1,7 @@
+---
+context: implementation
+---
+
 # Maintainability Specialist
 
 ## Identity & Narrative Backstory

--- a/skills/paw-sot/references/specialists/performance.md
+++ b/skills/paw-sot/references/specialists/performance.md
@@ -1,3 +1,7 @@
+---
+context: implementation
+---
+
 # Performance Specialist
 
 ## Identity & Narrative Backstory

--- a/skills/paw-sot/references/specialists/release-manager.md
+++ b/skills/paw-sot/references/specialists/release-manager.md
@@ -1,3 +1,7 @@
+---
+context: implementation
+---
+
 # Release Manager Specialist
 
 ## Identity & Narrative Backstory

--- a/skills/paw-sot/references/specialists/security.md
+++ b/skills/paw-sot/references/specialists/security.md
@@ -1,3 +1,7 @@
+---
+context: implementation
+---
+
 # Security Specialist
 
 ## Identity & Narrative Backstory

--- a/skills/paw-sot/references/specialists/testing.md
+++ b/skills/paw-sot/references/specialists/testing.md
@@ -1,3 +1,7 @@
+---
+context: implementation
+---
+
 # Testing Specialist
 
 ## Identity & Narrative Backstory


### PR DESCRIPTION
## Summary

Adds a generic context-filtering mechanism to the SoT engine so specialists can declare their domain via a `context` field in YAML frontmatter, and callers can filter to only relevant specialists for their review type.

## Motivation

Today, all SoT specialists are implementation-focused (security, architecture, performance, testing, etc.). There are real use cases for running SoT reviews against non-code content — business plans, discovery artifacts, documentation — where implementation specialists are irrelevant. This feature enables external workflows to bring their own domain-specific specialists without modifying PAW core.

## Changes

### paw-sot SKILL.md
- Added `context` field to review context input contract
- Added "Context Filtering" section documenting:
  - Specialist context declaration via frontmatter
  - Case-insensitive matching behavior  
  - Default behaviors for missing context
  - Zero-match handling (interactive prompt vs non-interactive fallback)
  - Execution order (filtering before adaptive selection)

### Built-in Specialists
- Added `context: implementation` frontmatter to all 9 built-in specialists

### Documentation
- Updated `docs/guide/society-of-thought-review.md` with context filtering section
- Added `context` field to specialist scaffold example

## Default Behaviors

| Scenario | Default |
|----------|---------|
| Specialist without `context` field | `implementation` |
| Caller without `context` + `diff`/`artifacts` type | `implementation` |
| Caller without `context` + `freeform` type | No filtering |

## Testing

- Agent lint passes: `./scripts/lint-prompting.sh skills/paw-sot/SKILL.md`
- Skills lint passes: `npm run lint:skills`
- Docs build passes: `mkdocs build --strict`

## References

Closes lossyrob/phased-agent-workflow#262