### PR TITLE
feat: evaluate consider-severity findings with quick-win heuristic in non-interactive review

### DIFF
--- a/docs/guide/society-of-thought-review.md
+++ b/docs/guide/society-of-thought-review.md
@@ -321,7 +321,7 @@ When `Final Review Interactive` is `true` or `smart`, you can interact with spec
 - **Challenge** a finding — the specialist must respond with independent evidence
 - **Request deeper analysis** on a particular file or function
 
-With `smart` mode, interactive sessions activate only when significant findings (must-fix or should-fix) are present. If the review produces only `consider` items, it completes without interruption.
+With `smart` mode, interactive sessions activate only when significant findings (must-fix or should-fix) are present. If the review produces only `consider` items that don't qualify as quick wins, it completes without interruption — though quick-win consider items are still auto-applied.
 
 ## Model Assignment
 

--- a/skills/paw-final-review/SKILL.md
+++ b/skills/paw-final-review/SKILL.md
@@ -215,7 +215,8 @@ If `Final Review Mode` is `multi-model`, classify each synthesis finding, then r
 | Consensus | should-fix | `auto-apply` |
 | Partial | must-fix/should-fix | `interactive` |
 | Single-model | must-fix/should-fix | `interactive` |
-| Any | consider | `report-only` |
+| Consensus | consider | `quick-win evaluation`* |
+| Partial/Single | consider | `report-only` |
 
 Consensus agreement implies models converged on the fix — no per-model cross-referencing needed.
 
@@ -227,16 +228,20 @@ If `Final Review Mode` is `society-of-thought`, classify each REVIEW-SYNTHESIS.m
 | HIGH | Direct | should-fix | `auto-apply` |
 | HIGH | Inferential | must-fix/should-fix | `interactive` |
 | MEDIUM/LOW | any | must-fix/should-fix | `interactive` |
-| Any | any | consider | `report-only` |
+| HIGH | Direct | consider | `quick-win evaluation`* |
+| Other | any | consider | `report-only` |
 | — | — | trade-off | `interactive` (always) |
 
-**Phase 1 — Auto-apply**: Apply all `auto-apply` findings without user interaction. Display batch summary:
+*Quick-win evaluation: auto-apply if **all three** hold: (1) trivial fix — < ~2 min, localized change; (2) clearly net-positive — no design tradeoff, scope expansion, or new dependencies; (3) improves safety, correctness, or clarity — not purely style. For SoT findings, security/correctness categories and multi-specialist agreement favor applying. Otherwise → `report-only`.
+
+**Phase 1 — Auto-apply**: Apply all `auto-apply` and quick-win findings without user interaction. Display batch summary:
 
 ```
 ## Auto-Applied Findings (N items)
 
 1. **[Title]** (must-fix) — [one-line description]
 2. **[Title]** (should-fix) — [one-line description]
+3. **[Title]** (consider, quick-win) — [one-line description]
 ...
 ```
 
@@ -247,13 +252,13 @@ If `Final Review Mode` is `society-of-thought`, classify each REVIEW-SYNTHESIS.m
 ```
 ## Resolution Summary
 
-**Auto-applied**: N findings (consensus fixes)
+**Auto-applied**: N findings (consensus fixes + quick wins)
 **User-applied**: N findings
 **User-skipped**: N findings
-**Reported only**: N findings (consider-severity)
+**Deferred**: N findings (consider-severity, with one-line reasons)
 ```
 
-If all findings are `auto-apply` or `report-only`, skip Phase 2. If all findings are `interactive`, skip Phase 1.
+If all findings are `auto-apply`/`quick-win` or `report-only`, skip Phase 2. If all findings are `interactive`, skip Phase 1.
 {{/cli}}
 {{#vscode}}
 Smart mode degrades to interactive behavior in VS Code (single-model has no agreement signal). Follow the `Interactive = true` flow above.
@@ -261,7 +266,7 @@ Smart mode degrades to interactive behavior in VS Code (single-model has no agre
 
 **If Interactive = false**:
 
-Auto-apply all findings marked `must-fix` and `should-fix`. Skip `consider` items. Report what was applied.
+Auto-apply all `must-fix` and `should-fix` findings. For each `consider` finding, apply the quick-win evaluation* — auto-apply if it passes, otherwise report as a deferred consider with a one-line reason. Report all applied and deferred findings.
 
 {{#cli}}
 #### Moderator Mode (society-of-thought only)

--- a/skills/paw-planning-docs-review/SKILL.md
+++ b/skills/paw-planning-docs-review/SKILL.md
@@ -235,17 +235,21 @@ If `Planning Review Mode` is `multi-model`, classify each synthesis finding, the
 | Consensus | must-fix/should-fix | both | `interactive` → user chooses routing |
 | Partial | must-fix/should-fix | any | `interactive` |
 | Single-model | must-fix/should-fix | any | `interactive` |
-| Any | consider | any | `report-only` |
+| Consensus | consider | spec or plan (single) | `quick-win evaluation`* → auto-route if applied |
+| Partial/Single | consider | any | `report-only` |
 
 Consensus agreement implies models converged on the fix. Single-artifact consensus findings are auto-routed: `spec` → paw-spec (Revise), `plan` → paw-planning (Revision). Multi-artifact findings always pause for user routing even at consensus.
 
-**Phase 1 — Auto-apply**: Apply all `auto-apply` findings without user interaction, routing each to the appropriate skill. Display batch summary:
+*Quick-win evaluation: auto-apply if **all three** hold: (1) trivial fix — < ~2 min, localized change; (2) clearly net-positive — no design tradeoff, scope expansion, or new dependencies; (3) improves safety, correctness, or clarity — not purely style. For SoT findings, security/correctness categories and multi-specialist agreement favor applying. Otherwise → `report-only`.
+
+**Phase 1 — Auto-apply**: Apply all `auto-apply` and quick-win findings without user interaction, routing each to the appropriate skill. Display batch summary:
 
 ```
 ## Auto-Applied Findings (N items)
 
 1. **[Title]** (must-fix) → applied to spec — [one-line description]
 2. **[Title]** (should-fix) → applied to plan — [one-line description]
+3. **[Title]** (consider, quick-win) → applied to spec — [one-line description]
 ...
 ```
 
@@ -256,13 +260,13 @@ Consensus agreement implies models converged on the fix. Single-artifact consens
 ```
 ## Resolution Summary
 
-**Auto-applied**: N findings (consensus single-artifact fixes)
+**Auto-applied**: N findings (consensus fixes + quick wins)
 **User-applied**: N findings (to-spec: X, to-plan: Y, to-both: Z)
 **User-skipped**: N findings
-**Reported only**: N findings (consider-severity)
+**Deferred**: N findings (consider-severity, with one-line reasons)
 ```
 
-If all findings are `auto-apply` or `report-only`, skip Phase 2. If all findings are `interactive`, skip Phase 1.
+If all findings are `auto-apply`/`quick-win` or `report-only`, skip Phase 2. If all findings are `interactive`, skip Phase 1.
 
 Smart mode classification applies independently per re-review cycle (Step 6) since synthesis is regenerated from modified artifacts each cycle.
 
@@ -274,7 +278,8 @@ If `Planning Review Mode` is `society-of-thought`, classify each REVIEW-SYNTHESI
 | HIGH | Direct | must-fix/should-fix | both | `interactive` → user chooses routing |
 | HIGH | Inferential | must-fix/should-fix | any | `interactive` |
 | MEDIUM/LOW | any | must-fix/should-fix | any | `interactive` |
-| Any | any | consider | any | `report-only` |
+| HIGH | Direct | consider | spec or plan (single) | `quick-win evaluation`* → auto-route if applied |
+| Other | any | consider | any | `report-only` |
 | — | — | trade-off | any | `interactive` (always) |
 
 Single-artifact HIGH+Direct findings are auto-routed: `spec` → paw-spec (Revise), `plan` → paw-planning (Revision). Multi-artifact findings always pause for user routing. Follow the same Phase 1/2/3 resolution flow as multi-model smart mode.
@@ -287,7 +292,7 @@ Smart mode degrades to interactive behavior in VS Code (single-model has no agre
 
 **If Interactive = false**:
 
-Auto-apply all `must-fix` and `should-fix` findings. Skip `consider` items. Route each to the appropriate planning skill based on affected artifact. Report what was applied.
+Auto-apply all `must-fix` and `should-fix` findings. For each `consider` finding, apply the quick-win evaluation* — auto-apply if it passes, otherwise report as a deferred consider with a one-line reason. Route each applied finding to the appropriate planning skill based on affected artifact. Report all applied and deferred findings.
 
 ### Step 6: Re-Review (if revisions were made)
 
@@ -307,7 +312,7 @@ The `paw-sot` moderator mode handles specialist summoning, finding challenges, a
 
 **Exit**: User says "done", "continue", or "proceed" to exit moderator mode and continue to implementation.
 
-**Skip condition**: If `Planning Review Interactive` is `false`, or no findings exist, or `smart` with only consider-tier findings, skip moderator mode entirely.
+**Skip condition**: If `Planning Review Interactive` is `false`, or no findings exist, or `smart` with only consider-tier findings and none qualify as quick wins, skip moderator mode entirely.
 {{/cli}}
 
 ### Step 7: Completion

--- a/skills/paw-sot/SKILL.md
+++ b/skills/paw-sot/SKILL.md
@@ -300,4 +300,4 @@ Announce moderator mode with a brief prompt: available specialists, interaction 
 
 **Exit**: User says "done", "continue", or "proceed" to exit moderator mode.
 
-**Skip condition**: If `interactive` is `false`, no findings exist, or `interactive` is `smart` with no significant findings (only `consider`-tier), skip moderator mode entirely.
+**Skip condition**: If `interactive` is `false`, no findings exist, or `interactive` is `smart` with no significant findings (only `consider`-tier and none qualify as quick wins), skip moderator mode entirely.

--- a/tests/integration/tests/workflows/smart-interactive-mode.test.ts
+++ b/tests/integration/tests/workflows/smart-interactive-mode.test.ts
@@ -4,7 +4,7 @@
  * Verifies that smart mode correctly classifies synthesis findings:
  * - Consensus must-fix/should-fix → auto-apply
  * - Partial/single-model must-fix/should-fix → interactive
- * - Any consider → report-only
+ * - Consensus consider → quick-win evaluation (auto-apply if trivial+net-positive+improves safety/correctness/clarity, otherwise report-only)
  *
  * Seeds: Spec.md, ImplementationPlan.md, CodeResearch.md, WorkflowContext.md (smart config)
  * Exercises: Smart classification heuristic, phased resolution (auto-apply → interactive → summary)
@@ -165,7 +165,7 @@ describe("smart interactive mode classification", { timeout: 300_000 }, () => {
       context: [
         "Agent was given planning artifacts to review with smart interactive mode.",
         "Smart mode should: auto-apply consensus fixes, present partial/single findings interactively,",
-        "and report consider-severity as report-only.",
+        "and evaluate consider-severity findings as quick wins (auto-apply if trivial, net-positive, and improves safety/correctness/clarity) or defer with reason.",
         "",
         "Agent produced this response:",
       ].join("\n"),


### PR DESCRIPTION
## Summary

Instead of blanket-skipping all `consider` findings in non-interactive mode, evaluate each with a **quick-win heuristic**: auto-apply if the fix is trivial, clearly net-positive, and improves safety/correctness/clarity. Otherwise defer with a one-line reason.

## Changes

- **`paw-final-review`** and **`paw-planning-docs-review`**: Updated `Interactive = false` to evaluate considers instead of skipping; split classification tables so consensus/HIGH+Direct considers get quick-win evaluation while others remain report-only; updated phase descriptions and summary templates
- **`paw-sot`**: Updated moderator mode skip condition to account for quick-win consider findings
- **`docs/guide/society-of-thought-review.md`**: Updated smart mode description
- **`smart-interactive-mode.test.ts`**: Updated test expectations

## Quick-Win Heuristic (all three must hold)

1. **Trivial fix** — < ~2 min, localized change
2. **Net-positive** — no design tradeoff, scope expansion, or new dependencies
3. **Improves safety, correctness, or clarity** — not purely style

For SoT: security/correctness categories and multi-specialist agreement favor applying.

Closes #280