### PR TITLE
Fix Copilot plugin marketplace installation

### DIFF
--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -1,0 +1,31 @@
+{
+  "name": "paw-workflow",
+  "owner": {
+    "name": "Rob Emanuele"
+  },
+  "metadata": {
+    "description": "Marketplace for the Phased Agent Workflow (PAW) Copilot CLI plugin",
+    "version": "0.3.0"
+  },
+  "plugins": [
+    {
+      "name": "paw-workflow",
+      "description": "Phased Agent Workflow (PAW) — structured multi-phase implementation and PR review workflows for AI coding agents",
+      "version": "0.3.0",
+      "source": ".",
+      "author": {
+        "name": "Rob Emanuele"
+      },
+      "repository": "https://github.com/lossyrob/phased-agent-workflow",
+      "license": "MIT",
+      "keywords": [
+        "paw",
+        "workflow",
+        "agent",
+        "copilot",
+        "implementation",
+        "code-review"
+      ]
+    }
+  ]
+}

--- a/.github/prompts/prepare-cli-release.prompt.md
+++ b/.github/prompts/prepare-cli-release.prompt.md
@@ -84,9 +84,10 @@ Guidelines:
 - Link PR numbers to their URLs
 - Omit empty categories
 - Add an installation section at the end with:
-  - Plugin install: `copilot plugin install lossyrob/phased-agent-workflow` (always installs from `main`)
+  - Marketplace setup: `copilot plugin marketplace add lossyrob/phased-agent-workflow`
+  - Plugin install: `copilot plugin install paw-workflow@paw-workflow` (always installs from `main`)
   - NPM versioned install: `npx @paw-workflow/cli@<version>` and `npm install -g` options
-  - Note: The Copilot CLI plugin always installs from the `main` branch. For pinned versions, use the npm CLI.
+  - Note: The Copilot CLI marketplace plugin always installs from the `main` branch. For pinned versions, use the npm CLI.
 
 Present the changelog to the user for review. After approval, post it to the GitHub release:
 

--- a/README.md
+++ b/README.md
@@ -9,10 +9,12 @@
 ### Copilot CLI Plugin (Recommended)
 
 ```bash
-copilot plugin install lossyrob/phased-agent-workflow
+copilot plugin marketplace add lossyrob/phased-agent-workflow
+copilot plugin marketplace browse paw-workflow
+copilot plugin install paw-workflow@paw-workflow
 ```
 
-This installs PAW as a [Copilot CLI plugin](https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/plugins-finding-installing) with native update and uninstall support. Then start a workflow:
+This installs PAW as a [Copilot CLI plugin](https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/plugins-marketplace) from the PAW marketplace, with native update and uninstall support. If you previously installed PAW directly from the repository, uninstall that copy first with `copilot plugin uninstall paw-workflow`. Then start a workflow:
 
 ```bash
 copilot --agent PAW          # Implementation workflow
@@ -21,7 +23,7 @@ copilot --agent PAW-Review   # PR review workflow
 
 Or use `/agent` inside your session to switch agents.
 
-Update with `copilot plugin update paw-workflow`, uninstall with `copilot plugin uninstall paw-workflow`.
+Refresh the marketplace catalog with `copilot plugin marketplace update paw-workflow`, update with `copilot plugin update paw-workflow`, and uninstall with `copilot plugin uninstall paw-workflow`.
 
 **Requirements**: [GitHub Copilot CLI](https://github.com/github/copilot-cli) installed.
 
@@ -58,7 +60,7 @@ PAW works with both **GitHub Copilot CLI** (terminal) and **VS Code** (GUI):
 
 | Platform | Installation | Best For |
 |----------|--------------|----------|
-| **Copilot CLI** (Plugin) | `copilot plugin install lossyrob/phased-agent-workflow` | Terminal workflows, quick iteration |
+| **Copilot CLI** (Plugin) | `copilot plugin marketplace add lossyrob/phased-agent-workflow` then `copilot plugin install paw-workflow@paw-workflow` | Terminal workflows, quick iteration |
 | **Copilot CLI** (NPM) | `npx @paw-workflow/cli install copilot` | Fallback, or if you also use Claude Code |
 | **VS Code Extension** | Download `.vsix` from [Releases](https://github.com/lossyrob/phased-agent-workflow/releases) | IDE integration, visual workflow |
 
@@ -93,16 +95,19 @@ All comments are created as a pending review—you edit, delete, or add to them 
 
 Install as a Copilot CLI plugin:
 ```bash
-copilot plugin install lossyrob/phased-agent-workflow
+copilot plugin marketplace add lossyrob/phased-agent-workflow
+copilot plugin marketplace browse paw-workflow
+copilot plugin install paw-workflow@paw-workflow
 ```
 
 Then start a session with `copilot --agent PAW` or `copilot --agent PAW-Review`.
 
 Manage your installation:
 ```bash
-copilot plugin list                     # Show installed plugins
-copilot plugin update paw-workflow      # Update to latest
-copilot plugin uninstall paw-workflow   # Remove PAW
+copilot plugin marketplace update paw-workflow  # Refresh PAW marketplace catalog
+copilot plugin list                             # Show installed plugins
+copilot plugin update paw-workflow              # Update installed plugin
+copilot plugin uninstall paw-workflow           # Remove PAW
 ```
 
 <details>
@@ -116,7 +121,7 @@ npx @paw-workflow/cli upgrade           # Check for updates
 npx @paw-workflow/cli uninstall         # Remove PAW
 ```
 
-**Note**: If switching from NPM CLI to the plugin, uninstall the NPM version first to avoid duplicate agents (user-level files take precedence over plugin files).
+**Note**: If switching from NPM CLI or the old direct repository plugin install to the marketplace plugin, uninstall the previous copy first to avoid duplicate agents (user-level files take precedence over plugin files).
 </details>
 
 ### VS Code Extension
@@ -148,4 +153,3 @@ Configuration is set in `WorkflowContext.md` during initialization. See the [PAW
 Inspired by Dex Horthy's "Advanced Context Engineering for Coding Agents" [talk](https://youtu.be/IS_y40zY-hc?si=27dVJV7LlYDh7woA) and [writeup](https://github.com/humanlayer/advanced-context-engineering-for-coding-agents/blob/main/ace-fca.md). Original agent prompts adapted from HumanLayer's [Claude subagents and commands](https://github.com/humanlayer/humanlayer/tree/main/.claude).
 
 Specification structure and checklist concepts were further informed by ideas from the open-source [Spec Kit](https://github.com/github/spec-kit) project, whose emphasis on prioritized user stories, explicit clarification markers, measurable success criteria, and structured quality checklists influenced the current spec workflow adaptation.
-

--- a/cli/README.md
+++ b/cli/README.md
@@ -100,10 +100,12 @@ This creates `dist/` with processed agents and skills for the npm package.
 
 ### Plugin Distribution
 
-The Copilot CLI plugin reads `plugin.json` from the repository root on `main`. The `agents/` and `skills/` directories on `main` serve as the canonical source for plugin installation:
+The Copilot CLI marketplace reads `.github/plugin/marketplace.json`, which points at the repository root plugin manifest. The `agents/` and `skills/` directories on `main` serve as the canonical source for plugin installation:
 
 ```bash
-copilot plugin install lossyrob/phased-agent-workflow
+copilot plugin marketplace add lossyrob/phased-agent-workflow
+copilot plugin marketplace browse paw-workflow
+copilot plugin install paw-workflow@paw-workflow
 ```
 
 Users wanting versioned/stable installs should use the npm CLI (`npx @paw-workflow/cli@<version>`).

--- a/docs/guide/cli-installation.md
+++ b/docs/guide/cli-installation.md
@@ -8,19 +8,24 @@ Install PAW agents and skills to your GitHub Copilot CLI configuration.
 
 ## Plugin Installation (Recommended)
 
-Install PAW as a native Copilot CLI plugin:
+Install PAW as a native Copilot CLI plugin from the PAW marketplace:
 
 ```bash
-copilot plugin install lossyrob/phased-agent-workflow
+copilot plugin marketplace add lossyrob/phased-agent-workflow
+copilot plugin marketplace browse paw-workflow
+copilot plugin install paw-workflow@paw-workflow
 ```
 
-This installs PAW agents and skills as a managed plugin, with native update and uninstall support.
+This installs PAW agents and skills as a managed plugin, with native update and uninstall support. If you previously installed PAW directly from the repository, uninstall that copy first with `copilot plugin uninstall paw-workflow`.
 
 ### Plugin Commands
 
 | Command | Description |
 |---------|-------------|
-| `copilot plugin install lossyrob/phased-agent-workflow` | Install PAW plugin |
+| `copilot plugin marketplace add lossyrob/phased-agent-workflow` | Register the PAW marketplace |
+| `copilot plugin marketplace browse paw-workflow` | Confirm the marketplace exposes the PAW plugin |
+| `copilot plugin install paw-workflow@paw-workflow` | Install PAW plugin from the marketplace |
+| `copilot plugin marketplace update paw-workflow` | Refresh the PAW marketplace catalog |
 | `copilot plugin list` | Show installed plugins |
 | `copilot plugin update paw-workflow` | Update to latest version |
 | `copilot plugin uninstall paw-workflow` | Remove PAW plugin |
@@ -56,16 +61,18 @@ Use `--force` or `-f` to skip confirmation prompts.
 
 ## What Gets Installed
 
+The marketplace plugin is managed by Copilot CLI and exposes PAW agents and skills from the plugin. The NPM CLI alternative writes the same agents and skills into `~/.copilot/` or `~/.claude/`.
+
 ### Agents
 
-Two agent files are installed to `~/.copilot/agents/`:
+Two agent files are provided:
 
 - **PAW.agent.md** - The main PAW workflow orchestrator for implementation workflows
 - **PAW-Review.agent.md** - The PAW Review workflow orchestrator for code review
 
 ### Skills
 
-Activity and utility skills are installed to `~/.copilot/skills/`, including:
+Activity and utility skills are provided, including:
 
 - Specification skills: `paw-spec`, `paw-spec-research`, `paw-spec-review`
 - Planning skills: `paw-planning`, `paw-plan-review`, `paw-code-research`
@@ -91,13 +98,20 @@ See [Two Workflows](two-workflows.md) for detailed usage instructions.
 
 ## Updating
 
-Check for updates and upgrade:
+For marketplace plugin installs:
+
+```bash
+copilot plugin marketplace update paw-workflow
+copilot plugin update paw-workflow
+```
+
+For NPM CLI installs:
 
 ```bash
 npx @paw-workflow/cli upgrade
 ```
 
-Or reinstall to get the latest version:
+Or reinstall the NPM CLI copy to get the latest version:
 
 ```bash
 npx @paw-workflow/cli install copilot --force
@@ -105,15 +119,21 @@ npx @paw-workflow/cli install copilot --force
 
 ## Uninstalling
 
-Remove all PAW files:
+For marketplace plugin installs:
+
+```bash
+copilot plugin uninstall paw-workflow
+```
+
+For NPM CLI installs:
 
 ```bash
 npx @paw-workflow/cli uninstall
 ```
 
-This removes installed agents, skills, and the manifest file.
+The NPM uninstall removes installed agents, skills, and the manifest file.
 
-## Switching from NPM CLI to Plugin
+## Switching from NPM CLI or Direct Repository Install to Plugin
 
 If you previously installed PAW via the NPM CLI and want to switch to the plugin:
 
@@ -123,15 +143,18 @@ If you previously installed PAW via the NPM CLI and want to switch to the plugin
    ```
 2. Install as a plugin:
    ```bash
-   copilot plugin install lossyrob/phased-agent-workflow
+   copilot plugin marketplace add lossyrob/phased-agent-workflow
+   copilot plugin install paw-workflow@paw-workflow
    ```
+
+If you previously installed PAW directly with `copilot plugin install lossyrob/phased-agent-workflow`, uninstall it first with `copilot plugin uninstall paw-workflow`, then reinstall from the marketplace.
 
 !!! warning
     If both installations are active, the NPM-installed files at `~/.copilot/agents/` take precedence over plugin-provided agents (Copilot CLI uses first-found-wins for agents and skills).
 
 ## Troubleshooting
 
-### "Distribution files not found"
+### NPM CLI: "Distribution files not found"
 
 The package may be corrupted. Try reinstalling:
 
@@ -142,7 +165,14 @@ npx @paw-workflow/cli install copilot
 
 ### Files not showing in Copilot CLI
 
-Verify the files were installed:
+For marketplace plugin installs, verify the marketplace and plugin are registered:
+
+```bash
+copilot plugin marketplace browse paw-workflow
+copilot plugin list
+```
+
+For NPM CLI installs, verify the files were installed:
 
 ```bash
 ls ~/.copilot/agents/
@@ -153,6 +183,6 @@ Restart your Copilot CLI session after installation.
 
 ### Permission errors
 
-Ensure you have write access to:
+For NPM CLI installs, ensure you have write access to:
 - `~/.copilot/` — where agents and skills are installed
 - `~/.paw/copilot-cli/` — where the manifest file is stored


### PR DESCRIPTION
## Summary
- Add `.github/plugin/marketplace.json` so PAW can be registered as a Copilot CLI plugin marketplace.
- Update README, CLI install guide, CLI package README, and release prompt instructions to install with `paw-workflow@paw-workflow` instead of direct repository install.
- Document migration from the old direct repository plugin install and split marketplace plugin management from the NPM installer path.

## Validation
- `npm run lint`
- `bash ./scripts/lint-prompting.sh .github/prompts/prepare-cli-release.prompt.md`
- `mkdocs build --strict`
- Local marketplace registration/browse smoke test with Copilot CLI
