### PR TITLE
Bump Copilot plugin version to 0.4.0

### DIFF
--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Marketplace for the Phased Agent Workflow (PAW) Copilot CLI plugin",
-    "version": "0.3.0"
+    "version": "0.4.0"
   },
   "plugins": [
     {
       "name": "paw-workflow",
       "description": "Phased Agent Workflow (PAW) — structured multi-phase implementation and PR review workflows for AI coding agents",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "source": ".",
       "author": {
         "name": "Rob Emanuele"

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "paw-workflow",
   "description": "Phased Agent Workflow (PAW) — structured multi-phase implementation and PR review workflows for AI coding agents",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "author": {
     "name": "Rob Emanuele",
     "url": "https://github.com/lossyrob"


### PR DESCRIPTION
## Summary
- Bump the root Copilot CLI `plugin.json` version from `0.3.0` to `0.4.0`.
- Align `.github/plugin/marketplace.json` marketplace and plugin entry versions with the `cli-v0.4.0` release.

## Validation
- `npm run lint`
- Manifest consistency check: plugin and marketplace versions match `0.4.0`
